### PR TITLE
Translator for lightkurve.LightCurve objects to glue Data objs

### DIFF
--- a/lcviz/__init__.py
+++ b/lcviz/__init__.py
@@ -5,6 +5,8 @@ try:
 except ImportError:
     __version__ = ''
 
+from . import utils  # noqa
+
 # Expose subpackage API at package level.
 from .plugins import *  # noqa
 from .parsers import *  # noqa

--- a/lcviz/conftest.py
+++ b/lcviz/conftest.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.utils.masked import Masked
+from lightkurve import LightCurve
+
+from lcviz import __version__
+
+
+@pytest.fixture
+def light_curve_like_kepler_quarter(seed=42):
+    """
+    Generate a normalized (near unity) light curve with
+    Gaussian noise. Times correspond very roughly to the
+    Kepler 30-min cadences in Quarter 10. A random masking
+    is applied to a small fraction of the fluxes.
+    """
+    np.random.seed(seed)
+    exp_per_day = (30 * u.min).to_value(u.day)
+    masked_fraction = 0.01
+
+    # approx start and stop JD for Kepler Quarter 10:
+    time = np.arange(2455739, 2455833, exp_per_day)
+    scale = 0.01
+    flux = np.random.normal(
+        1, scale=scale, size=len(time)
+    ) * u.dimensionless_unscaled
+    flux_err = scale * np.ones_like(flux)
+
+    # randomly apply mask to fraction of the data:
+    mask_indices = np.random.randint(
+        low=0,
+        high=len(flux),
+        size=int(masked_fraction * len(flux))
+    )
+    mask = np.zeros(len(flux), dtype=bool)
+    mask[mask_indices] = True
+
+    flux = Masked(flux, mask)
+    flux_err = Masked(flux_err, mask)
+    return LightCurve(
+        time=time, flux=flux, flux_err=flux_err
+    )
+
+
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+except ImportError:
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
+
+
+def pytest_configure(config):
+    PYTEST_HEADER_MODULES['astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['glue-core'] = 'glue'
+    PYTEST_HEADER_MODULES['glue-astronomy'] = 'glue_astronomy'
+    PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
+    PYTEST_HEADER_MODULES['lightkurve'] = 'lightkurve'
+
+    TESTED_VERSIONS['lcviz'] = __version__

--- a/lcviz/tests/test_translator.py
+++ b/lcviz/tests/test_translator.py
@@ -1,0 +1,34 @@
+from glue.core import DataCollection
+import numpy as np
+
+
+def test_translator(light_curve_like_kepler_quarter):
+    light_curve = light_curve_like_kepler_quarter
+    dc = DataCollection()
+    dc['dummy-lc'] = light_curve
+    translated_lc = dc['dummy-lc'].get_object()
+
+    # check for equality within these attrs:
+    attrs = ['time', 'flux', 'flux_err']
+
+    for attr in attrs:
+        expected = getattr(light_curve, attr)
+        translated = getattr(translated_lc, attr)
+
+        if attr == 'time':
+            args = (
+                expected.tdb.jd,
+                translated.tdb.jd
+            )
+        else:
+            args = (
+                expected.value,
+                translated.to_value(expected.unit)
+            )
+
+        # check that attribute's values match expectations:
+        np.testing.assert_allclose(*args)
+
+        if hasattr(expected, 'mask'):
+            # check that mask is preserved
+            assert np.all(expected.mask == translated.mask)

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -1,0 +1,112 @@
+from glue.config import data_translator
+from glue.core import Data, Subset
+
+from lightkurve import LightCurve
+from ndcube.extra_coords import TimeTableCoordinate
+from astropy import units as u
+from astropy.utils.masked import Masked
+
+
+@data_translator(LightCurve)
+class LightCurveHandler:
+
+    def to_data(self, obj):
+        time = obj.time
+        ttc = TimeTableCoordinate(time)
+        gwcs = ttc.wcs
+
+        data = Data(coords=gwcs)
+
+        data.meta.update(obj.meta)
+        data.meta.update({"reference_time": ttc.reference_time})
+
+        data['flux'] = obj.flux
+        data.get_component('flux').units = str(obj.flux.unit)
+
+        data['uncertainty'] = obj.flux_err
+        data.get_component('uncertainty').units = str(obj.flux_err.unit)
+        data.meta.update({'uncertainty_type': 'std'})
+
+        if hasattr(obj.flux, 'mask'):
+            data['mask'] = obj.flux.mask
+        return data
+
+    def to_object(self, data_or_subset, attribute=None):
+        """
+        Convert a glue Data object to a lightkurve.LightCurve object.
+
+        Parameters
+        ----------
+        data_or_subset : `glue.core.data.Data` or `glue.core.subset.Subset`
+            The data to convert to a Spectrum1D object
+        attribute : `glue.core.component_id.ComponentID`
+            The attribute to use for the Spectrum1D data
+        """
+
+        if isinstance(data_or_subset, Subset):
+            data = data_or_subset.data
+            subset_state = data_or_subset.subset_state
+        else:
+            data = data_or_subset
+            subset_state = None
+
+        # Copy over metadata
+        kwargs = {'meta': data.meta.copy()}
+
+        # convert gwcs coordinates to Time object.
+
+        # ``gwcs`` will store the transformation from pixel coordinates, which are
+        # integer indices in the input time object, to astropy.time.Time objects.
+        # Here we extract the time coordinates directly from the lookup table:
+        gwcs = data.coords
+        reference_time = data.meta['reference_time']
+        input_times = gwcs._pipeline[0].transform.lookup_table
+        kwargs['time'] = input_times + reference_time
+
+        if isinstance(attribute, str):
+            attribute = data.id[attribute]
+        elif len(data.main_components) == 0:
+            raise ValueError('Data object has no attributes.')
+        elif attribute is None:
+            if len(data.main_components) == 1:
+                attribute = data.main_components[0]
+            # If no specific attribute is defined, attempt to retrieve
+            # the flux and uncertainty, if available
+            elif any([x.label in ('time', 'flux', 'uncertainty') for x in data.components]):
+                attribute = [data.find_component_id(x)
+                             for x in ('time', 'flux', 'uncertainty')
+                             if data.find_component_id(x) is not None]
+            else:
+                raise ValueError("Data object has more than one attribute, so "
+                                 "you will need to specify which one to use as "
+                                 "the flux for the spectrum using the "
+                                 "attribute= keyword argument.")
+
+        def parse_attributes(attributes):
+            data_kwargs = {}
+            lc_init_keys = {'time': 'time', 'flux': 'flux', 'uncertainty': 'flux_err'}
+            for attribute in attributes:
+                component = data.get_component(attribute)
+
+                # Collapse values and mask to profile
+                values = data.get_data(attribute)
+                attribute_label = attribute.label
+
+                if attribute in ('flux', 'uncertainty'):
+                    values = u.Quantity(values, unit=component.units)
+                    if 'mask' in data.main_components:
+                        mask = data['mask'].astype(bool)
+                        values = Masked(values, mask)
+
+                if subset_state is not None and attribute != 'mask':
+                    glue_mask = data.get_mask(subset_state=subset_state)
+                    values = Masked(values, ~glue_mask)
+
+                init_kwarg = lc_init_keys[attribute_label]
+                data_kwargs[init_kwarg] = values
+
+            return data_kwargs
+
+        data_kwargs = parse_attributes(
+            [attribute] if not hasattr(attribute, '__len__') else attribute)
+        return LightCurve(**data_kwargs, **kwargs)


### PR DESCRIPTION
This PR has an implementation for a `glue-astronomy`-style translator from `lightkurve.LightCurve` objects to `glue.core.Data` objects. The contents of the `lcviz/utils.py` file will ultimately go into a PR to `glue-astronomy`, but I'm putting them here for now, so we don't have to wait on upstream releases to work here. 

My assigned ticket was to actually parse Kepler FITS files, which will be trivial after this first-step PR is merged, since those features are implemented in lightkurve. In the soon-to-come follow-up PR, I'll implement something like a `lightkurve_parser` which uses lightkurve's [`read` function](https://docs.lightkurve.org/reference/io.html) to construct a `LightCurve` from a Kepler or TESS data product, and rely on the translator in this PR to send the contents into glue `Data`.

[🐱](https://jira.stsci.edu/browse/JDAT-3143)