### PR TITLE
Implement basic API doc skeleton

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,3 +4,11 @@ LCviz Documentation
 
 This is the documentation for ``lcviz``,
 a package which contains stuff that do things.
+
+Reference/API
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   reference/api.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,3 @@ LCviz Documentation
 
 This is the documentation for ``lcviz``,
 a package which contains stuff that do things.
-
-Reference/API
-=============
-
-.. automodapi:: lcviz

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -20,5 +20,6 @@ Viewers
 
 Parsers
 =======
+
 .. automodapi:: lcviz.parsers
    :no-inheritance-diagram:

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -6,8 +6,8 @@ API
 
 .. _lcviz-api-configs:
 
-Configurations
-==============
+LCviz Helper
+============
 
 .. automodapi:: lcviz.helper
    :no-inheritance-diagram:

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -1,0 +1,24 @@
+.. _lcviz-api:
+
+###
+API
+###
+
+.. _lcviz-api-configs:
+
+Configurations
+==============
+
+.. automodapi:: lcviz.helper
+   :no-inheritance-diagram:
+
+Viewers
+=======
+
+.. automodapi:: lcviz.viewers
+   :no-inheritance-diagram:
+
+Parsers
+=======
+.. automodapi:: lcviz.parsers
+   :no-inheritance-diagram:

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -1,6 +1,8 @@
 from jdaviz.core.helpers import ConfigHelper
 from glue.core import Data
 
+__all__ = ['LCviz']
+
 
 class LCviz(ConfigHelper):
     _default_configuration = {

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -7,6 +7,8 @@ from glue_jupyter.bqplot.profile import BqplotProfileView
 from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 
+__all__ = ['TimeProfileView']
+
 
 @viewer_registry("lcviz-time-viewer", label="Profile 1D (LCviz)")
 class TimeProfileView(JdavizViewerMixin, BqplotProfileView):


### PR DESCRIPTION
Sphinx was producing an error that it couldn't find api docs that don't exist. This PR implements basic API docs and the necessary skeleton to render properly. Thanks to Pey-Lian for the `__all__` heads up!