### PR TITLE
jdaviz spectrum viewer inheritance

### DIFF
--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -6,6 +6,8 @@ from glue_jupyter.bqplot.profile import BqplotProfileView
 
 from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
+from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
+from jdaviz.core.freezable_state import FreezableProfileViewerState
 
 
 @viewer_registry("lcviz-time-viewer", label="Profile 1D (LCviz)")
@@ -18,10 +20,18 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
                     ['bqplot:xrange'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
+    _state_cls = FreezableProfileViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.initialize_toolbar()
+        self._subscribe_to_layers_update()
+        # hack to inherit a small subset of methods from SpecvizProfileView
+        # TODO: refactor jdaviz so these can be included in some mixin
+        self._show_uncertainty_changed = lambda value: SpecvizProfileView._show_uncertainty_changed(self, value)  # noqa
+        self._plot_uncertainties = lambda: SpecvizProfileView._plot_uncertainties(self)
+        # TODO: _plot_uncertainties in specviz is hardcoded to look at spectral_axis and so crashes
+        self._clean_error = lambda: SpecvizProfileView._clean_error(self)
 
     def data(self, cls=None):
         return [layer_state.layer


### PR DESCRIPTION
This PR "fixes" (in a really hacky way) some missing methods that we need from jdaviz's spectrum viewer that are not available in the `JdavizViewerMixin` mixin that `TimeProfileView` inherits.  We don't want to inherit directly from `SpecvizProfileView`, because that comes with a lot of spectrum-specific methods that we don't want here.  Ideally, we should refactor this on the jdaviz-end to pull these shared methods into a separate mixin which can then be used from lcviz.