### PR TITLE
Adding support for subsets in time

### DIFF
--- a/lcviz/conftest.py
+++ b/lcviz/conftest.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.utils.masked import Masked
 from lightkurve import LightCurve
 
 from lcviz import __version__, LCviz
@@ -22,7 +21,6 @@ def light_curve_like_kepler_quarter(seed=42):
     """
     np.random.seed(seed)
     exp_per_day = (30 * u.min).to_value(u.day)
-    masked_fraction = 0.01
 
     # approx start and stop JD for Kepler Quarter 10:
     time = np.arange(2455739, 2455833, exp_per_day)
@@ -32,19 +30,10 @@ def light_curve_like_kepler_quarter(seed=42):
     ) * u.dimensionless_unscaled
     flux_err = scale * np.ones_like(flux)
 
-    # randomly apply mask to fraction of the data:
-    mask_indices = np.random.randint(
-        low=0,
-        high=len(flux),
-        size=int(masked_fraction * len(flux))
-    )
-    mask = np.zeros(len(flux), dtype=bool)
-    mask[mask_indices] = True
+    quality = np.zeros(len(time), dtype=np.int32)
 
-    flux = Masked(flux, mask)
-    flux_err = Masked(flux_err, mask)
     return LightCurve(
-        time=time, flux=flux, flux_err=flux_err
+        time=time, flux=flux, flux_err=flux_err, quality=quality
     )
 
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -37,7 +37,10 @@ class LCviz(ConfigHelper):
                      'dense_toolbar': False,
                      'context': {'notebook': {'max_height': '600px'}}},
         'toolbar': ['g-data-tools', 'g-subset-tools'],
-        'tray': ['g-metadata-viewer', 'g-plot-options', 'g-subset-plugin', 'HelloWorldPlugin', 'g-export-plot'],
+        'tray': [
+            'g-metadata-viewer', 'g-plot-options', 'g-subset-plugin',
+            'HelloWorldPlugin', 'g-export-plot'
+        ],
         'viewer_area': [{'container': 'col',
                          'children': [{'container': 'row',
                                        'viewers': [{'name': 'time-viewer',

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -1,4 +1,5 @@
 from jdaviz.core.helpers import ConfigHelper
+from lightkurve import LightCurve
 
 __all__ = ['LCviz']
 
@@ -13,7 +14,7 @@ class LCviz(ConfigHelper):
                      'dense_toolbar': False,
                      'context': {'notebook': {'max_height': '600px'}}},
         'toolbar': ['g-data-tools', 'g-subset-tools'],
-        'tray': ['g-metadata-viewer', 'g-plot-options', 'HelloWorldPlugin', 'g-export-plot'],
+        'tray': ['g-metadata-viewer', 'g-plot-options', 'g-subset-plugin', 'HelloWorldPlugin', 'g-export-plot'],
         'viewer_area': [{'container': 'col',
                          'children': [{'container': 'row',
                                        'viewers': [{'name': 'time-viewer',
@@ -47,3 +48,25 @@ class LCviz(ConfigHelper):
             parser_reference='light_curve_parser',
             data_label=data_label
         )
+
+    def get_data(self, data_label=None, cls=LightCurve, subset_to_apply=None):
+        """
+        Returns data with name equal to data_label of type cls with subsets applied from
+        subset_to_apply.
+
+        Parameters
+        ----------
+        data_label : str, optional
+            Provide a label to retrieve a specific data set from data_collection.
+        cls : `~specutils.Spectrum1D`, `~astropy.nddata.CCDData`, optional
+            The type that data will be returned as.
+        subset_to_apply : str, optional
+            Subset that is to be applied to data before it is returned.
+
+        Returns
+        -------
+        data : cls
+            Data is returned as type cls with subsets applied.
+
+        """
+        return super()._get_data(data_label=data_label, cls=cls, subset_to_apply=subset_to_apply)

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -82,7 +82,7 @@ def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
         subset_plugin._obj.subset_selected = "Create New"
         viewer.apply_roi(XRangeROI(*time_range))
 
-    subsets = helper.app.get_subsets()
+    subsets = helper.app.get_subsets_from_viewer('time-viewer')
 
     subset_1_bounds_jd = subsets['Subset 1'][0]['region'].jd
     subset_2_bounds_jd = subsets['Subset 2'][0]['region'].jd

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -1,12 +1,13 @@
 # import pytest
 import numpy as np
+from glue.core.roi import XRangeROI
 from astropy.time import Time
 # from astropy.utils.data import download_file
 from lightkurve import LightCurve
 # from lightkurve.io import kepler
-from gwcs.wcs import WCS
 import astropy.units as u
 
+from lcviz.utils import TimeCoordinates
 
 # @pytest.mark.remote_data
 # def test_kepler_via_mast_local_file(helper):
@@ -23,7 +24,7 @@ import astropy.units as u
 #     flux_unit = u.Unit(data.get_component('flux').units)
 #     flux = flux_arr * flux_unit
 #
-#     assert isinstance(data.coords, WCS)
+#     assert isinstance(data.coords, TimeCoordinates)
 #     assert isinstance(flux, u.Quantity)
 #     assert flux.unit.is_equivalent(u.electron / u.s)
 #
@@ -43,7 +44,7 @@ import astropy.units as u
 #     flux_unit = u.Unit(data.get_component('flux').units)
 #     flux = flux_arr * flux_unit
 #
-#     assert isinstance(data.coords, WCS)
+#     assert isinstance(data.coords, TimeCoordinates)
 #     assert isinstance(flux, u.Quantity)
 #     assert flux.unit.is_equivalent(u.electron / u.s)
 
@@ -60,6 +61,31 @@ def test_synthetic_lc(helper):
     flux_unit = u.Unit(data.get_component('flux').units)
     flux = flux_arr * flux_unit
 
-    assert isinstance(data.coords, WCS)
+    assert isinstance(data.coords, TimeCoordinates)
     assert isinstance(flux, u.Quantity)
     assert flux.unit.is_equivalent(u.electron / u.s)
+
+
+def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
+    lc = light_curve_like_kepler_quarter
+    helper.load_data(lc)
+    viewer = helper.app.get_viewer("time-viewer")
+    subset_plugin = helper.plugins['Subset Tools']
+
+    # the min/max of temporal regions can be defined in two ways:
+    time_ranges = [
+        [6, 8],  # in same units as the x axis, OR
+        Time(['2011-07-19', '2011-07-23'])  # directly with a Time object
+    ]
+
+    for time_range in time_ranges:
+        subset_plugin._obj.subset_selected = "Create New"
+        viewer.apply_roi(XRangeROI(*time_range))
+
+    subsets = helper.app.get_subsets()
+
+    subset_1_bounds_jd = subsets['Subset 1'][0]['region'].jd
+    subset_2_bounds_jd = subsets['Subset 2'][0]['region'].jd
+
+    np.testing.assert_allclose(subset_1_bounds_jd, [2455745., 2455747.])
+    np.testing.assert_allclose(subset_2_bounds_jd, [2455761.50076602, 2455765.50076602])

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -3,11 +3,8 @@ from glue.core import Data, Subset
 from ipyvue import watch
 
 import os
-from lightkurve import LightCurve
-from ndcube.extra_coords import TimeTableCoordinate
 from glue.core.coordinates import Coordinates
 import numpy as np
-from gwcs.wcs import WCS
 from astropy import units as u
 from astropy.time import Time
 
@@ -193,7 +190,6 @@ class LightCurveHandler:
         return LightCurve(**data_kwargs, **kwargs)
 
 
-<<<<<<< HEAD
 def enable_hot_reloading(watch_jdaviz=True):
     """
     Use ``watchdog`` to perform hot reloading.
@@ -212,7 +208,8 @@ def enable_hot_reloading(watch_jdaviz=True):
         print((
             'Watchdog module, needed for hot reloading, not found.'
             ' Please install with `pip install watchdog`'))
-=======
+
+
 @data_translator(KeplerLightCurve)
 class KeplerLightCurveHandler(LightCurveHandler):
     # Works the same as LightCurve
@@ -223,4 +220,3 @@ class KeplerLightCurveHandler(LightCurveHandler):
 class TessLightCurveHandler(LightCurveHandler):
     # Works the same as LightCurve
     pass
->>>>>>> ff59ea9 (First working subset fixes)

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -1,3 +1,4 @@
+import datetime
 from glue.config import data_translator
 from glue.core import Data, Subset
 from ipyvue import watch
@@ -5,8 +6,82 @@ from ipyvue import watch
 import os
 from lightkurve import LightCurve
 from ndcube.extra_coords import TimeTableCoordinate
+from glue.core.coordinates import Coordinates
+import numpy as np
+from gwcs.wcs import WCS
+
 from astropy import units as u
+from astropy.time import Time
 from astropy.utils.masked import Masked
+from lightkurve import LightCurve
+
+__all__ = ['TimeCoordinates']
+
+
+class TimeCoordinates(Coordinates):
+    """
+    This is a sub-class of Coordinates that is intended for a time axis
+    given by a :class:`~astropy.time.Time` array.
+    """
+
+    def __init__(self, times, reference_time=None, unit=u.d):
+        if not isinstance(times, Time):
+            raise TypeError('values should be a Time instance')
+        self._index = np.arange(len(times))
+        self._times = times
+
+        # convert to relative time units
+        if reference_time is None:
+            self.reference_time = times[0]
+
+        delta_t = (times - self.reference_time).to(unit)
+        self._values = delta_t # times.datetime64
+
+        # self._values = (
+        #     times.datetime64.astype(datetime.datetime).astype(int) / 1e9 * u.day
+        # )
+
+        super().__init__(n_dim=1)
+
+    @property
+    def time_axis(self):
+        """
+        Returns
+        -------
+        """
+        return self._times
+
+    @property
+    def world_axis_units(self):
+        return (self._values.unit.to_string('vounit'),)
+
+    def world_to_pixel_values(self, *world):
+        """
+        Parameters
+        ----------
+        world
+        Returns
+        -------
+        """
+        if len(world) > 1:
+            raise ValueError('TimeCoordinates is a 1-d coordinate class '
+                             'and only accepts a single scalar or array to convert')
+        return np.interp(world[0], self._values.value, self._index,
+                         left=np.nan, right=np.nan)
+
+    def pixel_to_world_values(self, *pixel):
+        """
+        Parameters
+        ----------
+        pixel
+        Returns
+        -------
+        """
+        if len(pixel) > 1:
+            raise ValueError('SpectralCoordinates is a 1-d coordinate class '
+                             'and only accepts a single scalar or array to convert')
+        return np.interp(pixel[0], self._index, self._values.value,
+                         left=np.nan, right=np.nan)
 
 
 __all__ = ['LightCurveHandler', 'enable_hot_reloading']
@@ -17,23 +92,29 @@ class LightCurveHandler:
 
     def to_data(self, obj):
         time = obj.time
-        ttc = TimeTableCoordinate(time)
-        gwcs = ttc.wcs
-
-        data = Data(coords=gwcs)
+        # ttc = TimeTableCoordinate(time)
+        # gwcs = ttc.wcs
+        time_coord = TimeCoordinates(obj.time)
+        # delta_t = (obj.time - obj.time[0]).to(u.d)
+        data = Data(coords=time_coord)
 
         data.meta.update(obj.meta)
-        data.meta.update({"reference_time": ttc.reference_time})
+        data.meta.update({"reference_time": obj.time[0]})
 
-        data['flux'] = obj.flux
-        data.get_component('flux').units = str(obj.flux.unit)
+        flux = obj.flux
+        flux_err = obj.flux_err
 
-        data['uncertainty'] = obj.flux_err
-        data.get_component('uncertainty').units = str(obj.flux_err.unit)
+        if hasattr(flux, 'unmasked'):
+            flux = flux.unmasked
+            flux_err = obj.flux_err.unmasked
+
+        data['flux'] = flux
+        data.get_component('flux').units = str(flux.unit)
+
+        data['uncertainty'] = flux_err
+        data.get_component('uncertainty').units = str(flux_err.unit)
         data.meta.update({'uncertainty_type': 'std'})
 
-        if hasattr(obj.flux, 'mask'):
-            data['mask'] = obj.flux.mask
         return data
 
     def to_object(self, data_or_subset, attribute=None):
@@ -43,9 +124,9 @@ class LightCurveHandler:
         Parameters
         ----------
         data_or_subset : `glue.core.data.Data` or `glue.core.subset.Subset`
-            The data to convert to a Spectrum1D object
+            The data to convert to a LightCurve object
         attribute : `glue.core.component_id.ComponentID`
-            The attribute to use for the Spectrum1D data
+            The attribute to use for the LightCurve data
         """
 
         if isinstance(data_or_subset, Subset):
@@ -63,10 +144,14 @@ class LightCurveHandler:
         # ``gwcs`` will store the transformation from pixel coordinates, which are
         # integer indices in the input time object, to astropy.time.Time objects.
         # Here we extract the time coordinates directly from the lookup table:
-        gwcs = data.coords
         reference_time = data.meta['reference_time']
-        input_times = gwcs._pipeline[0].transform.lookup_table
-        kwargs['time'] = input_times + reference_time
+
+        if isinstance(data.coords, WCS):
+            gwcs = data.coords
+            input_times = gwcs._pipeline[0].transform.lookup_table
+            kwargs['time'] = input_times + reference_time
+        else:
+            kwargs['time'] = data.coords.time_axis
 
         if isinstance(attribute, str):
             attribute = data.id[attribute]
@@ -77,38 +162,38 @@ class LightCurveHandler:
                 attribute = data.main_components[0]
             # If no specific attribute is defined, attempt to retrieve
             # the flux and uncertainty, if available
-            elif any([x.label in ('time', 'flux', 'uncertainty') for x in data.components]):
+            elif any([x.label in ('flux', 'uncertainty') for x in data.components]):
                 attribute = [data.find_component_id(x)
-                             for x in ('time', 'flux', 'uncertainty')
+                             for x in ('flux', 'uncertainty')
                              if data.find_component_id(x) is not None]
             else:
                 raise ValueError("Data object has more than one attribute, so "
                                  "you will need to specify which one to use as "
                                  "the flux for the spectrum using the "
                                  "attribute= keyword argument.")
-
+        print('attributes', attribute)
         def parse_attributes(attributes):
             data_kwargs = {}
-            lc_init_keys = {'time': 'time', 'flux': 'flux', 'uncertainty': 'flux_err'}
+            lc_init_keys = {'flux': 'flux', 'uncertainty': 'flux_err'}
             for attribute in attributes:
                 component = data.get_component(attribute)
 
+                # Get mask if there is one defined, or if this is a subset
+                if subset_state is None:
+                    mask = None
+                else:
+                    mask = data.get_mask(subset_state=subset_state)
+                    # mask = ~mask
+                print('mask', mask, np.any(mask))
                 # Collapse values and mask to profile
                 values = data.get_data(attribute)
                 attribute_label = attribute.label
 
                 if attribute in ('flux', 'uncertainty'):
                     values = u.Quantity(values, unit=component.units)
-                    if 'mask' in data.main_components:
-                        mask = data['mask'].astype(bool)
-                        values = Masked(values, mask)
-
-                if subset_state is not None and attribute != 'mask':
-                    glue_mask = data.get_mask(subset_state=subset_state)
-                    values = Masked(values, ~glue_mask)
 
                 init_kwarg = lc_init_keys[attribute_label]
-                data_kwargs[init_kwarg] = values
+                data_kwargs.update({init_kwarg: values})
 
             return data_kwargs
 

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -51,6 +51,10 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
     def data(self, cls=None):
         data = []
 
+        # TODO: generalize upstream in jdaviz.
+        # This method is generalized from
+        # jdaviz/configs/specviz/plugins/viewers.py
+        # to support non-spectral viewers.
         for layer_state in self.state.layers:
             if hasattr(layer_state, 'layer'):
                 lyr = layer_state.layer

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -1,6 +1,8 @@
 from astropy import units as u
-
+from glue.core.subset import Subset
+from glue.config import data_translator
 from glue.core import BaseData
+from glue.core.exceptions import IncompatibleAttribute
 
 from glue_jupyter.bqplot.profile import BqplotProfileView
 
@@ -8,6 +10,9 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 from jdaviz.core.freezable_state import FreezableProfileViewerState
+
+from lightkurve import LightCurve
+
 
 __all__ = ['TimeProfileView']
 
@@ -22,10 +27,13 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
                     ['bqplot:xrange'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
+    default_class = LightCurve
     _state_cls = FreezableProfileViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # self._subscribe_to_layers_update()
         self.initialize_toolbar()
         self._subscribe_to_layers_update()
         # hack to inherit a small subset of methods from SpecvizProfileView
@@ -36,19 +44,48 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
         self._clean_error = lambda: SpecvizProfileView._clean_error(self)
 
     def data(self, cls=None):
-        return [layer_state.layer
-                for layer_state in self.state.layers
-                if hasattr(layer_state, 'layer') and
-                isinstance(layer_state.layer, BaseData)]
+        data = []
+
+        for layer_state in self.state.layers:
+            if hasattr(layer_state, 'layer'):
+                lyr = layer_state.layer
+
+                # For raw data, just include the data itself
+                if isinstance(lyr, BaseData):
+                    _class = cls or self.default_class
+
+                    if _class is not None:
+                        cache_key = lyr.label
+                        if cache_key in self.jdaviz_app._get_object_cache:
+                            layer_data = self.jdaviz_app._get_object_cache[cache_key]
+                        else:
+                            layer_data = lyr.get_object(cls=_class)
+                            self.jdaviz_app._get_object_cache[cache_key] = layer_data
+
+                        data.append(layer_data)
+
+                # For subsets, make sure to apply the subset mask to the layer data first
+                elif isinstance(lyr, Subset):
+                    layer_data = lyr
+
+                    if _class is not None:
+                        handler, _ = data_translator.get_handler_for(_class)
+                        try:
+                            layer_data = handler.to_object(layer_data)
+                        except IncompatibleAttribute:
+                            continue
+                    data.append(layer_data)
+
+        return data
 
     def set_plot_axes(self):
         # Get data to be used for axes labels
-        data = self.data()[0]
+        light_curve = self.data()[0]
 
         # Get the lookup table from the time axis in the gwcs obj:
-        lookup_table = data.coords._pipeline[0].transform.lookup_table
-        x_unit = lookup_table.unit
-        reference_time = data.meta.get('reference_time', None)
+        # lookup_table = data.coords._pipeline[0].transform.lookup_table
+        x_unit = u.day ##data.coords._values.unit
+        reference_time = light_curve.meta.get('reference_time', None)
 
         if reference_time is not None:
             xlabel = f'{str(x_unit.physical_type).title()} from {reference_time.iso} ({x_unit})'
@@ -57,7 +94,7 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
 
         self.figure.axes[0].label = xlabel
 
-        y_unit = u.Unit(data.get_component('flux').units)
+        y_unit = light_curve.flux.unit
         y_unit_physical_type = str(y_unit.physical_type).title()
 
         common_count_rate_units = (u.electron / u.s, u.dn / u.s, u.ct / u.s)
@@ -81,3 +118,41 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
         # Set (X,Y)-axis to scientific notation if necessary:
         self.figure.axes[0].tick_format = 'g'
         self.figure.axes[1].tick_format = 'g'
+
+    def _expected_subset_layer_default(self, layer_state):
+        super()._expected_subset_layer_default(layer_state)
+
+        layer_state.linewidth = 3
+
+    def add_data(self, data, color=None, alpha=None, **layer_state):
+        """
+        Overrides the base class to add markers for plotting
+        uncertainties and data quality flags.
+
+        Parameters
+        ----------
+        data : :class:`glue.core.data.Data`
+            Data object with the spectrum.
+        color : obj
+            Color value for plotting.
+        alpha : float
+            Alpha value for plotting.
+
+        Returns
+        -------
+        result : bool
+            `True` if successful, `False` otherwise.
+        """
+        # The base class handles the plotting of the main
+        # trace representing the spectrum itself.
+        result = super().add_data(data, color, alpha, **layer_state)
+
+        # Set default linewidth on any created spectral subset layers
+        # NOTE: this logic will need updating if we add support for multiple cubes as this assumes
+        # that new data entries (from model fitting or gaussian smooth, etc) will only be spectra
+        # and all subsets affected will be spectral
+        for layer in self.state.layers:
+            if "Subset" in layer.layer.label and layer.layer.data.label == data.label:
+                layer.linewidth = 3
+
+        return result


### PR DESCRIPTION
This PR gets time subsets working for LCviz. [🐱](https://jira.stsci.edu/browse/JDAT-3297)

https://user-images.githubusercontent.com/3497584/234955643-55aeb31c-5a7e-4283-94a1-0fbc1bbd7ca9.mov

Covered in this PR:
* Added a Kepler/TESS quality flag component to the translated `LightCurve`s (will later useful for masking)
* adapted the `LightCurve` translator in lcviz to enable subset selections from light curves
    * Made a new glue `Coordinates` subclass to use for the time axis (analog of glue-astro’s `SpectralCoordinates`)
* Added translators for the `KeplerLightCurve` and `TessLightCurve` subclasses of `LightCurve` (so the type of the input `*LightCurve` object is preserved on round-trip)

This PR depends on upstream updates to jdaviz as of https://github.com/spacetelescope/jdaviz/pull/2168, which adds support for temporal subset selection.