### PR TITLE
Add jdaviz badge to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ LCviz
     :target: http://www.astropy.org
     :alt: Powered by Astropy Badge
 
-.. image:: http://img.shields.io/badge/powered%20by-jdaviz-355973.svg?style=flat
+.. image:: http://img.shields.io/badge/powered%20by-jdaviz-336699.svg?style=flat
     :target: https://github.com/spacetelescope/jdaviz/
     :alt: Powered by jdaviz Badge
 

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ LCviz
     :target: http://www.astropy.org
     :alt: Powered by Astropy Badge
 
+.. image:: http://img.shields.io/badge/powered%20by-jdaviz-355973.svg?style=flat
+    :target: https://github.com/spacetelescope/jdaviz/
+    :alt: Powered by jdaviz Badge
+
 
 Early Development Software Warning
 ----------------------------------


### PR DESCRIPTION
I've chosen the color of the jdaviz label to be the darker-blue jdaviz logo color `#355973` used on the `Jda` part of the logo. We could also choose the lighter one `#336699` used in the `viz` part.

*Update*: I've opted for the lighter blue now.