### PR TITLE
support for markers instead of lines via ScatterViewer

### DIFF
--- a/lcviz/__init__.py
+++ b/lcviz/__init__.py
@@ -12,5 +12,6 @@ from . import state  # noqa
 # Expose subpackage API at package level.
 from .plugins import *  # noqa
 from .parsers import *  # noqa
+from .tools import *  # noqa
 from .viewers import *  # noqa
 from .helper import *  # noqa

--- a/lcviz/__init__.py
+++ b/lcviz/__init__.py
@@ -7,6 +7,7 @@ except ImportError:
 
 from . import utils  # noqa
 from .utils import enable_hot_reloading  # noqa: F401
+from . import state  # noqa
 
 # Expose subpackage API at package level.
 from .plugins import *  # noqa

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -13,9 +13,12 @@ def _get_range_subset_bounds(self, subset_state, *args, **kwargs):
     # _default_time_viewer_reference_name, (2) using the LCviz version if so, and (3)
     # using the jdaviz version otherwise.
     viewer = self.get_viewer(self._jdaviz_helper._default_time_viewer_reference_name)
-    reference_time = viewer.state.reference_data.meta['reference_time']
+    light_curve = viewer.data()[0]
+    reference_time = light_curve.meta['reference_time']
     if viewer:
-        units = u.Unit(viewer.state.x_display_unit)
+        # TODO: use display units once implemented in Glue for ScatterViewer
+        # units = u.Unit(viewer.state.x_display_unit)
+        units = u.Unit(viewer.time_unit)
     else:
         raise ValueError("Unable to find time axis units")
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -43,13 +43,13 @@ class LCviz(ConfigHelper):
         ],
         'viewer_area': [{'container': 'col',
                          'children': [{'container': 'row',
-                                       'viewers': [{'name': 'time-viewer',
+                                       'viewers': [{'name': 'flux-vs-time',
                                                     'plot': 'lcviz-time-viewer',
-                                                    'reference': 'time-viewer'}]}]}]}
+                                                    'reference': 'flux-vs-time'}]}]}]}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_time_viewer_reference_name = 'time-viewer'
+        self._default_time_viewer_reference_name = 'flux-vs-time'
 
         # override jdaviz behavior to support temporal subsets
         self.app._get_range_subset_bounds = (

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -41,7 +41,7 @@ class LCviz(ConfigHelper):
                      'context': {'notebook': {'max_height': '600px'}}},
         'toolbar': ['g-data-tools', 'g-subset-tools'],
         'tray': [
-            'g-metadata-viewer', 'g-plot-options', 'g-subset-plugin',
+            'g-metadata-viewer', 'lcviz-plot-options', 'g-subset-plugin',
             'HelloWorldPlugin', 'g-export-plot'
         ],
         'viewer_area': [{'container': 'col',

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -48,7 +48,7 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     if len(dc) > 1:
         # then we need to link this light curve back to the first
         dc0_comps = {str(comp): comp for comp in dc[0].components}
-        new_links = [LinkSame(dc0_comps.get(str(new_comp)), new_comp) for new_comp in dc[-1].components]
+        new_links = [LinkSame(dc0_comps.get(str(new_comp)), new_comp) for new_comp in dc[-1].components]  # noqa
         dc.set_links(new_links)
 
     if show_in_viewer:

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -1,5 +1,6 @@
 import os
 from astropy.io import fits
+from glue.core.link_helpers import LinkSame
 from jdaviz.core.registries import data_parser_registry
 from lightkurve import LightCurve, KeplerLightCurve, TessLightCurve
 from lightkurve.io.detect import detect_filetype
@@ -43,6 +44,12 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         new_data_label += f'[{flux_origin}]'
 
     app.add_data(light_curve, new_data_label)
+    dc = app.data_collection
+    if len(dc) > 1:
+        # then we need to link this light curve back to the first
+        dc0_comps = {str(comp): comp for comp in dc[0].components}
+        new_links = [LinkSame(dc0_comps.get(str(new_comp)), new_comp) for new_comp in dc[-1].components]
+        dc.set_links(new_links)
 
     if show_in_viewer:
         app.add_data_to_viewer(time_viewer_reference_name, new_data_label)

--- a/lcviz/plugins/__init__.py
+++ b/lcviz/plugins/__init__.py
@@ -1,1 +1,2 @@
 from .hello_world.hello_world import *  # noqa
+from .plot_options.plot_options import *  # noqa

--- a/lcviz/plugins/plot_options/__init__.py
+++ b/lcviz/plugins/plot_options/__init__.py
@@ -1,0 +1,1 @@
+from .plot_options import *  # noqa

--- a/lcviz/plugins/plot_options/plot_options.py
+++ b/lcviz/plugins/plot_options/plot_options.py
@@ -1,0 +1,21 @@
+from jdaviz.configs.default.plugins import PlotOptions
+from jdaviz.core.registries import tray_registry
+
+__all__ = ['PlotOptions']
+
+
+@tray_registry('lcviz-plot-options', label="Plot Options")
+class PlotOptions(PlotOptions):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def user_api(self):
+        api = super().user_api
+        api._expose += ['marker_visible', 'marker_fill', 'marker_opacity',
+                        'marker_size_mode', 'marker_size', 'marker_size_scale',
+                        'marker_size_col', 'marker_size_vmin', 'marker_size_vmax',
+                        'marker_color_mode', 'marker_color',
+                        'marker_colormap', 'marker_colormap_vmin', 'marker_colormap_vmax']
+
+        return api

--- a/lcviz/state.py
+++ b/lcviz/state.py
@@ -1,0 +1,35 @@
+from echo import delay_callback
+import numpy as np
+
+from glue.viewers.scatter.state import ScatterViewerState
+
+__all__ = ['ScatterViewerState']
+
+
+class ScatterViewerState(ScatterViewerState):
+    def _reset_att_limits(self, ax):
+        # override glue's _reset_x/y_limits to account for all layers,
+        # not just reference data
+        att = f'{ax}_att'
+        if getattr(self, att) is None:
+            return
+
+        ax_min, ax_max = np.inf, -np.inf
+        for layer in self.layers:
+            ax_data = layer.layer.data.get_data(getattr(self, att))
+            if len(ax_data) > 0:
+                ax_min = min(ax_min, np.nanmin(ax_data))
+                ax_max = max(ax_max, np.nanmax(ax_data))
+
+        if not np.all(np.isfinite([ax_min, ax_max])):
+            return
+
+        with delay_callback(self, f'{ax}_min', f'{ax}_max'):
+            setattr(self, f'{ax}_min', ax_min)
+            setattr(self, f'{ax}_max', ax_max)
+
+    def _reset_x_limit(self, *event):
+        self._reset_att_limits('x')
+
+    def _reset_y_limits(self, *event):
+        self._reset_att_limits('y')

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -69,7 +69,7 @@ def test_synthetic_lc(helper):
 def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
     lc = light_curve_like_kepler_quarter
     helper.load_data(lc)
-    viewer = helper.app.get_viewer("time-viewer")
+    viewer = helper.app.get_viewer(helper._default_time_viewer_reference_name)
     subset_plugin = helper.plugins['Subset Tools']
 
     # the min/max of temporal regions can be defined in two ways:
@@ -82,7 +82,7 @@ def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
         subset_plugin._obj.subset_selected = "Create New"
         viewer.apply_roi(XRangeROI(*time_range))
 
-    subsets = helper.app.get_subsets_from_viewer('time-viewer')
+    subsets = helper.app.get_subsets_from_viewer(helper._default_time_viewer_reference_name)
 
     subset_1_bounds_jd = subsets['Subset 1'][0]['region'].jd
     subset_2_bounds_jd = subsets['Subset 2'][0]['region'].jd

--- a/lcviz/tools.py
+++ b/lcviz/tools.py
@@ -1,0 +1,5 @@
+from jdaviz.core.tools import SidebarShortcutPlotOptions
+
+
+# point to the lcviz-version of plot options instead of jdaviz's
+SidebarShortcutPlotOptions.plugin_name = 'lcviz-plot-options'

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -13,6 +13,8 @@ from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 
+from lcviz.state import ScatterViewerState
+
 from lightkurve import LightCurve
 
 
@@ -30,6 +32,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
     default_class = LightCurve
+    _state_cls = ScatterViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -2,6 +2,7 @@ from glue.core.subset import Subset
 from glue.config import data_translator
 from glue.core import BaseData
 from glue.core.exceptions import IncompatibleAttribute
+from glue.core.roi import RangeROI
 from glue.core.subset_group import GroupedSubset
 
 from glue_jupyter.bqplot.scatter import BqplotScatterView
@@ -28,7 +29,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
                     ['jdaviz:homezoom', 'jdaviz:prevzoom'],
                     ['jdaviz:boxzoom', 'jdaviz:xrangezoom'],
                     ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
-                    ['bqplot:xrange'],
+                    ['bqplot:xrange', 'bqplot:yrange', 'bqplot:rectangle'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
     default_class = LightCurve
@@ -175,11 +176,12 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
         pass
 
     def apply_roi(self, roi, use_current=False):
-        # allow ROIs describing times to be applied with min and max defined as:
-        #  1. floats, representing bounds in units of ``self.time_unit``
-        #  2. Time objects, which get converted to work like (1) via the reference time
-        if isinstance(roi.min, Time) or isinstance(roi.max, Time):
-            reference_time = self.data()[0].meta.get('reference_time', 0)
-            roi = roi.transformed(xfunc=lambda x: (x - reference_time).to_value(self.time_unit))
+        if isinstance(roi, RangeROI):
+            # allow ROIs describing times to be applied with min and max defined as:
+            #  1. floats, representing bounds in units of ``self.time_unit``
+            #  2. Time objects, which get converted to work like (1) via the reference time
+            if isinstance(roi.min, Time) or isinstance(roi.max, Time):
+                reference_time = self.data()[0].meta.get('reference_time', 0)
+                roi = roi.transformed(xfunc=lambda x: (x - reference_time).to_value(self.time_unit))
 
         super().apply_roi(roi, use_current=use_current)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -179,7 +179,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
         #  1. floats, representing bounds in units of ``self.time_unit``
         #  2. Time objects, which get converted to work like (1) via the reference time
         if isinstance(roi.min, Time) or isinstance(roi.max, Time):
-            reference_time = self.state.reference_data.meta['reference_time']
+            reference_time = self.data()[0].meta.get('reference_time', 0)
             roi = roi.transformed(xfunc=lambda x: (x - reference_time).to_value(self.time_unit))
 
         super().apply_roi(roi, use_current=use_current)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -4,7 +4,7 @@ from glue.core import BaseData
 from glue.core.exceptions import IncompatibleAttribute
 from glue.core.subset_group import GroupedSubset
 
-from glue_jupyter.bqplot.profile import BqplotProfileView
+from glue_jupyter.bqplot.scatter import BqplotScatterView
 
 from astropy import units as u
 from astropy.time import Time
@@ -12,16 +12,15 @@ from astropy.time import Time
 from jdaviz.core.registries import viewer_registry
 from jdaviz.configs.default.plugins.viewers import JdavizViewerMixin
 from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
-from jdaviz.core.freezable_state import FreezableProfileViewerState
 
 from lightkurve import LightCurve
 
 
-__all__ = ['TimeProfileView']
+__all__ = ['TimeScatterView']
 
 
-@viewer_registry("lcviz-time-viewer", label="Profile 1D (LCviz)")
-class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
+@viewer_registry("lcviz-time-viewer", label="flux-vs-time")
+class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
     # categories: zoom resets, zoom, pan, subset, select tools, shortcuts
     tools_nested = [
                     ['jdaviz:homezoom', 'jdaviz:prevzoom'],
@@ -31,7 +30,6 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
     default_class = LightCurve
-    _state_cls = FreezableProfileViewerState
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -89,6 +87,12 @@ class TimeProfileView(JdavizViewerMixin, BqplotProfileView):
     def set_plot_axes(self):
         # Get data to be used for axes labels
         light_curve = self.data()[0]
+
+        # set which components should be plotted
+        dc = self.jdaviz_app.data_collection
+        component_labels = [comp.label for comp in dc[0].components]
+        self.state.y_att = dc[0].components[component_labels.index('flux')]
+        self.state.x_att = dc[0].components[component_labels.index('World 0')]
 
         x_unit = self.time_unit
         reference_time = light_curve.meta.get('reference_time', None)

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -3,35 +3,32 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c6d00c0",
+   "id": "a21f400f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from lightkurve import search_lightcurve\n",
     "from lcviz import LCviz\n",
+    "\n",
+    "lc = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=10).download()\n",
+    "\n",
     "lcviz = LCviz()\n",
+    "lcviz.load_data(lc)\n",
     "lcviz.show()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a21f400f",
+   "id": "8dde219d-c9f1-4967-9437-e0abdcbd32b5",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import astropy.units as u\n",
-    "from glue.core import Data\n",
-    "\n",
-    "time = [0,1,2,3,4,5,6,7,8,9] * u.s\n",
-    "flux = [9,8,7,6,5,4,3,2,1,0] * u.Jy\n",
-    "\n",
-    "lcviz.load_data(time=time, flux=flux, data_label=\"mydata\")"
-   ]
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.10 ('envmain': venv)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -45,7 +42,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.3"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
This PR swaps out the ProfileViewer with ScatterViewer so that we can view the light curve as markers instead of lines and eventually have different arrays along the x-axis (for phase-viewer support).

This also overrides the `user_api` for the plot options plugin, but requires https://github.com/spacetelescope/jdaviz/pull/2193 in order to have access to the necessary glue-state objects and UI for those entries in the plugin itself.  This can be tested against that PR, but will eventually need a bump in the version of jdaviz once that PR is finalized/released.  If for some reason the decision is made to not merge that into jdaviz, the plot options logic can be added to lcviz as a follow-up PR.

With the exception of plot options, everything else should work with jdaviz main.