### PR TITLE
enable yrangezoom

### DIFF
--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -27,7 +27,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
     # categories: zoom resets, zoom, pan, subset, select tools, shortcuts
     tools_nested = [
                     ['jdaviz:homezoom', 'jdaviz:prevzoom'],
-                    ['jdaviz:boxzoom', 'jdaviz:xrangezoom'],
+                    ['jdaviz:boxzoom', 'jdaviz:xrangezoom', 'jdaviz:yrangezoom'],
                     ['jdaviz:panzoom', 'jdaviz:panzoom_x', 'jdaviz:panzoom_y'],
                     ['bqplot:xrange', 'bqplot:yrange', 'bqplot:rectangle'],
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']


### PR DESCRIPTION
This PR enables a vertical/y-range zoom tool in the light curve viewers, and requires https://github.com/spacetelescope/jdaviz/pull/2206 (merged in main, but currently unreleased)