### PR TITLE
fix CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
+    "ipywidgets>=8.0.6",  # until jdaviz pin is updated
     "jdaviz",
     "lightkurve>=2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ filterwarnings = [
     "error",
     "ignore:numpy\\.ndarray size changed:RuntimeWarning",
     "ignore:zmq\\.eventloop\\.ioloop is deprecated in pyzmq:DeprecationWarning",
+    "ignore::DeprecationWarning:asdf",
     "ignore::DeprecationWarning:glue",
     "ignore::DeprecationWarning:bqplot",
     "ignore::DeprecationWarning:bqplot_image_gl",


### PR DESCRIPTION
This PR pins the version of the `ipywidgets` package so that CI can (hopefully) run.  Once jdaviz is released, the pin for jdaviz can be updated and this should be able to be safely removed.