### PR TITLE
require jdaviz 3.5+

### DIFF
--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -82,7 +82,7 @@ def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
         subset_plugin._obj.subset_selected = "Create New"
         viewer.apply_roi(XRangeROI(*time_range))
 
-    subsets = helper.app.get_subsets_from_viewer(helper._default_time_viewer_reference_name)
+    subsets = helper.app.get_subsets()
 
     subset_1_bounds_jd = subsets['Subset 1'][0]['region'].jd
     subset_2_bounds_jd = subsets['Subset 2'][0]['region'].jd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "jdaviz",
+    "jdaviz>=3.5.0",
     "lightkurve>=2",
 ]
 dynamic = [


### PR DESCRIPTION
This PR sets the min version requirement for jdaviz to 3.5+ and will hopefully fix most/all of the CI failures 🤞 