### PR TITLE
fix bug that raised traceback when creating subsets

### DIFF
--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -160,7 +160,7 @@ class LightCurveHandler:
 
             values = component.data[glue_mask]
 
-            if isinstance(values[0], Time):
+            if len(values) and isinstance(values[0], Time):
                 values = Time(values.base)
             elif hasattr(component, 'units') and component.units != "None":
                 values = u.Quantity(values, component.units)


### PR DESCRIPTION
introduced by [mouseover coordinates](https://github.com/spacetelescope/lcviz/pull/22) trying to access `viewer.data()[0].flux.unit`