### PR TITLE
binning plugin

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -210,6 +210,26 @@ The ephemeris plugin allows for setting, finding, and refining the ephemeris or 
 for phase-folding.
 
 
+.. admonition:: User API Example
+    :class: dropdown
+
+    See the :class:`~lcviz.plugins.ephemeris.ephemeris.Ephemeris` user API documentation for more details.
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      ephem = lcviz.plugins['Ephemeris']
+      ephem.period = 4.88780258
+      ephem.t0 = 2.43
+      ephem.rename_component('default', 'my component name')
+
+
 .. _binning:
 
 Binning
@@ -232,10 +252,10 @@ This plugin supports binning a light curve in time or phase-space.
       lcviz.load_data(lc)
       lcviz.show()
 
-      ephem = lcviz.plugins['Ephemeris']
-      ephem.period = 4.88780258
-      ephem.t0 = 2.43
-      ephem.rename_component('default', 'my component name')
+      binning = lcviz.plugins['Binning']
+      binning.n_bins = 150
+      binned_lc = binning.bin(add_data=True)
+      print(binned_lc)
 
 
 .. seealso::

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -211,6 +211,8 @@ This plugin supports binning a light curve in time or phase-space.
 .. admonition:: User API Example
     :class: dropdown
 
+    See the :class:`~lcviz.plugins.binning.binning.Binning` user API documentation for more details.
+
     .. code-block:: python
 
       from lcviz import LCviz

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -194,11 +194,17 @@ This plugin exposes the periodogram (in period or frequency space) for an input 
 .. _ephemeris:
 
 Ephemeris
-============
+==========
 
 The ephemeris plugin allows for setting, finding, and refining the ephemeris or ephemerides used
 for phase-folding.
 
+.. _binning:
+
+Binning
+=======
+
+This plugin supports binning a light curve in time or phase-space.
 
 .. admonition:: User API Example
     :class: dropdown

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -199,12 +199,14 @@ Ephemeris
 The ephemeris plugin allows for setting, finding, and refining the ephemeris or ephemerides used
 for phase-folding.
 
+
 .. _binning:
 
 Binning
 =======
 
 This plugin supports binning a light curve in time or phase-space.
+
 
 .. admonition:: User API Example
     :class: dropdown
@@ -222,6 +224,13 @@ This plugin supports binning a light curve in time or phase-space.
       ephem.period = 4.88780258
       ephem.t0 = 2.43
       ephem.rename_component('default', 'my component name')
+
+
+.. seealso::
+
+  This plugin uses the following ``lightkurve`` implementations:
+
+  * :meth:`lightkurve.LightCurve.bin`
 
 
 .. _export-plot:

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -13,6 +13,8 @@ This plugin allows viewing of any metadata associated with the selected data.
 .. admonition:: User API Example
     :class: dropdown
 
+    See the :class:`~lcviz.plugins.metadata_viewer.metadata_viewer.MetadataViewer` user API documentation for more details.
+
     .. code-block:: python
 
       from lcviz import LCviz
@@ -43,6 +45,8 @@ This plugin gives access to per-viewer and per-layer plotting options.
 
 .. admonition:: User API Example
     :class: dropdown
+
+    See the :class:`~lcviz.plugins.plot_options.plot_options.PlotOptions` user API documentation for more details.
 
     .. code-block:: python
 
@@ -97,6 +101,8 @@ visible when the plugin is opened.
 .. admonition:: User API Example
     :class: dropdown
 
+    See the :class:`~lcviz.plugins.markers.markers.Markers` user API documentation for more details.
+
     .. code-block:: python
 
       from lcviz import LCviz
@@ -132,6 +138,8 @@ can be disabled through the plugin settings.
 .. admonition:: User API Example
     :class: dropdown
 
+    See the :class:`~lcviz.plugins.flatten.flatten.Flatten` user API documentation for more details.
+
     .. code-block:: python
 
       from lcviz import LCviz
@@ -165,6 +173,8 @@ This plugin exposes the periodogram (in period or frequency space) for an input 
 
 .. admonition:: User API Example
     :class: dropdown
+
+    See the :class:`~lcviz.plugins.frequency_analysis.frequency_analysis.FrequencyAnalysis` user API documentation for more details.
 
     .. code-block:: python
 
@@ -245,6 +255,8 @@ This plugin allows exporting the plot in a given viewer to various image formats
 
 .. admonition:: User API Example
     :class: dropdown
+
+    See the :class:`~lcviz.plugins.export_plot.export_plot.ExportViewer` user API documentation for more details.
 
     .. code-block:: python
 

--- a/docs/reference/api_plugins.rst
+++ b/docs/reference/api_plugins.rst
@@ -3,6 +3,9 @@
 Plugins API
 ===========
 
+.. automodapi:: lcviz.plugins.binning.binning
+  :no-inheritance-diagram:
+
 .. automodapi:: lcviz.plugins.ephemeris.ephemeris
   :no-inheritance-diagram:
 

--- a/lcviz/components/plugin_ephemeris_select.vue
+++ b/lcviz/components/plugin_ephemeris_select.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+  <v-row v-if="items.length > 1 || show_if_single_entry">
+    <v-select
+      :menu-props="{ left: true }"
+      attach
+      :items="items"
+      v-model="selected"
+      @change="$emit('update:selected', $event)"
+      :label="label ? label : 'Ephemeris'"
+      :hint="hint ? hint : 'Select ephemeris.'"
+      :rules="rules ? rules : []"
+      item-text="label"
+      item-value="label"
+      persistent-hint
+    >
+    <template slot="selection" slot-scope="data">
+      <div class="single-line">
+        <span>
+          {{ data.item.label }}
+        </span>
+      </div>
+    </template>
+    <template slot="item" slot-scope="data">
+      <div class="single-line">
+        <span>
+          {{ data.item.label }}
+        </span>
+      </div>
+    </template>
+   </v-select>
+  </v-row>
+ </div>
+</template>
+<script>
+module.exports = {
+  props: ['items', 'selected', 'label', 'hint', 'rules', 'show_if_single_entry']
+};
+</script>
+
+<style>
+  .v-select__selections {
+    flex-wrap: nowrap !important;
+  }
+  .single-line {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+  }
+</style>

--- a/lcviz/events.py
+++ b/lcviz/events.py
@@ -1,6 +1,7 @@
 from glue.core.message import Message
 
-__all__ = ['ViewerRenamedMessage', 'EphemerisComponentChangedMessage']
+__all__ = ['ViewerRenamedMessage', 'EphemerisComponentChangedMessage',
+           'EphemerisChangedMessage']
 
 
 class ViewerRenamedMessage(Message):
@@ -28,3 +29,10 @@ class EphemerisComponentChangedMessage(Message):
             self.type = 'remove'
         else:
             raise ValueError("must provide at least one of old_lbl or new_lbl")
+
+
+class EphemerisChangedMessage(Message):
+    """Message emitted when the parameters of an ephemeris are updated/changed
+    in the ephemeris plugin"""
+    def __init__(self, ephemeris_label, *args, **kwargs):
+        self.ephemeris_label = ephemeris_label

--- a/lcviz/events.py
+++ b/lcviz/events.py
@@ -27,7 +27,7 @@ class EphemerisComponentChangedMessage(Message):
             self.type = 'add'
         elif old_lbl is not None and new_lbl is None:
             self.type = 'remove'
-        else:
+        else:  # pragma: no cover
             raise ValueError("must provide at least one of old_lbl or new_lbl")
 
 

--- a/lcviz/events.py
+++ b/lcviz/events.py
@@ -1,6 +1,6 @@
 from glue.core.message import Message
 
-__all__ = ['ViewerRenamedMessage']
+__all__ = ['ViewerRenamedMessage', 'EphemerisComponentChangedMessage']
 
 
 class ViewerRenamedMessage(Message):
@@ -8,13 +8,23 @@ class ViewerRenamedMessage(Message):
     def __init__(self, old_viewer_ref, new_viewer_ref, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._old_viewer_ref = old_viewer_ref
-        self._new_viewer_ref = new_viewer_ref
+        self.old_viewer_ref = old_viewer_ref
+        self.new_viewer_ref = new_viewer_ref
 
-    @property
-    def old_viewer_ref(self):
-        return self._old_viewer_ref
 
-    @property
-    def new_viewer_ref(self):
-        return self._new_viewer_ref
+class EphemerisComponentChangedMessage(Message):
+    """Message emitted when an ephemeris component is added/renamed/removed in the
+    ephemeris plugin"""
+    def __init__(self, old_lbl, new_lbl, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.old_lbl = old_lbl
+        self.new_lbl = new_lbl
+        if old_lbl is not None and new_lbl is not None:
+            self.type = 'rename'
+        elif old_lbl is None and new_lbl is not None:
+            self.type = 'add'
+        elif old_lbl is not None and new_lbl is None:
+            self.type = 'remove'
+        else:
+            raise ValueError("must provide at least one of old_lbl or new_lbl")

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -4,6 +4,7 @@ import os
 
 from lightkurve import LightCurve
 
+from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
 from jdaviz.core.helpers import ConfigHelper
 from lcviz.events import ViewerRenamedMessage
@@ -123,6 +124,8 @@ class LCviz(ConfigHelper):
                                                     'plot': 'lcviz-time-viewer',
                                                     'reference': 'flux-vs-time'}]}]}]}
 
+    _component_ids = {}
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._default_time_viewer_reference_name = _default_time_viewer_reference_name
@@ -191,3 +194,17 @@ class LCviz(ConfigHelper):
             Data is returned as type cls with subsets applied.
         """
         return super()._get_data(data_label=data_label, mask_subset=subset, cls=cls)
+
+    def _phase_comp_lbl(self, component):
+        return f'phase:{component}'
+
+    def _set_data_component(self, data, component_label, values):
+        if component_label not in self._component_ids:
+            self._component_ids[component_label] = ComponentID(component_label)
+
+        if self._component_ids[component_label] in data.components:
+            data.update_components({self._component_ids[component_label]: values})
+        else:
+            data.add_component(values, self._component_ids[component_label])
+
+        data.add_component(values, self._component_ids[component_label])

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -10,7 +10,11 @@ from lcviz.events import ViewerRenamedMessage
 
 __all__ = ['LCviz']
 
-custom_components = {'lcviz-editable-select': 'components/plugin_editable_select.vue'}
+
+_default_time_viewer_reference_name = 'flux-vs-time'
+
+custom_components = {'lcviz-editable-select': 'components/plugin_editable_select.vue',
+                     'plugin-ephemeris-select': 'components/plugin_ephemeris_select.vue'}
 
 # Register pure vue component. This allows us to do recursive component instantiation only in the
 # vue component file
@@ -112,7 +116,7 @@ class LCviz(ConfigHelper):
         'toolbar': ['g-data-tools', 'g-subset-tools', 'lcviz-coords-info'],
         'tray': ['lcviz-metadata-viewer', 'lcviz-plot-options', 'lcviz-subset-plugin',
                  'lcviz-markers', 'flatten', 'frequency-analysis', 'ephemeris',
-                 'lcviz-export-plot'],
+                 'binning', 'lcviz-export-plot'],
         'viewer_area': [{'container': 'col',
                          'children': [{'container': 'row',
                                        'viewers': [{'name': 'flux-vs-time',
@@ -121,7 +125,7 @@ class LCviz(ConfigHelper):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_time_viewer_reference_name = 'flux-vs-time'
+        self._default_time_viewer_reference_name = _default_time_viewer_reference_name
 
         # override jdaviz behavior to support temporal subsets
         self.app._get_range_subset_bounds = (

--- a/lcviz/marks.py
+++ b/lcviz/marks.py
@@ -3,7 +3,7 @@ import numpy as np
 from jdaviz.core.marks import PluginLine, PluginScatter
 from lcviz.viewers import PhaseScatterView
 
-__all__ = ['LivePreviewTrend', 'LivePreviewFlattened']
+__all__ = ['LivePreviewTrend', 'LivePreviewFlattened', 'LivePreviewBinning']
 
 
 class WithoutPhaseSupport:
@@ -41,3 +41,9 @@ class LivePreviewFlattened(PluginScatter, WithPhaseSupport):
         self.viewer = viewer
         kwargs.setdefault('default_size', 16)
         super().__init__(viewer, *args, **kwargs)
+
+
+class LivePreviewBinning(PluginScatter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('default_size', 16)
+        super().__init__(*args, **kwargs)

--- a/lcviz/marks.py
+++ b/lcviz/marks.py
@@ -43,7 +43,7 @@ class LivePreviewFlattened(PluginScatter, WithPhaseSupport):
         super().__init__(viewer, *args, **kwargs)
 
 
-class LivePreviewBinning(PluginScatter):
+class LivePreviewBinning(PluginScatter, WithPhaseSupport):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('default_size', 16)
         super().__init__(*args, **kwargs)

--- a/lcviz/plugins/__init__.py
+++ b/lcviz/plugins/__init__.py
@@ -1,3 +1,4 @@
+from .binning.binning import *  # noqa
 from .coords_info.coords_info import *  # noqa
 from .ephemeris.ephemeris import *  # noqa
 from .export_plot.export_plot import *  # noqa

--- a/lcviz/plugins/binning/__init__.py
+++ b/lcviz/plugins/binning/__init__.py
@@ -1,0 +1,1 @@
+from .binning import *  # noqa

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -12,6 +12,7 @@ from jdaviz.core.user_api import PluginUserApi
 from lcviz.events import EphemerisChangedMessage
 from lcviz.helper import _default_time_viewer_reference_name
 from lcviz.marks import LivePreviewBinning
+from lcviz.parsers import _data_with_reftime
 from lcviz.template_mixin import EphemerisSelectMixin
 
 
@@ -196,7 +197,8 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
             self.app._jdaviz_helper._set_data_component(data, phase_comp_lbl, lc.time.value)
 
         else:
-            data = None
+            # need to send through parser-logic to assign the correct reference time
+            data = _data_with_reftime(self.app, lc)
 
         if add_data:
             # add data to the collection/viewer

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -1,0 +1,156 @@
+from traitlets import Bool, observe
+
+from jdaviz.core.custom_traitlets import IntHandleEmpty
+from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
+from jdaviz.core.registries import tray_registry
+from jdaviz.core.template_mixin import (PluginTemplateMixin,
+                                        DatasetSelectMixin, AddResultsMixin)
+from jdaviz.core.user_api import PluginUserApi
+
+from lcviz.helper import _default_time_viewer_reference_name
+from lcviz.marks import LivePreviewBinning
+from lcviz.template_mixin import EphemerisSelectMixin
+
+
+__all__ = ['Binning']
+
+
+@tray_registry('binning', label="Binning")
+class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, AddResultsMixin):
+    """
+    See the :ref:`Binning Plugin Documentation <binning>` for more details.
+
+    Only the following attributes and methods are available through the
+    public plugin API.
+
+    * ``dataset`` (:class:`~jdaviz.core.template_mixin.DatasetSelect`):
+      Dataset to bin.
+    * ``ephemeris`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
+      Label of the component corresponding to the active ephemeris.
+    * :meth:`input_lc`
+      Data used as input to binning, based on ``dataset`` and ``ephemeris``.
+    * ``add_results`` (:class:`~jdaviz.core.template_mixin.AddResults`)
+    * :meth:`bin`
+    """
+    template_file = __file__, "binning.vue"
+
+    show_live_preview = Bool(True).tag(sync=True)
+
+    n_bins = IntHandleEmpty(100).tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._set_results_viewer()
+
+        # TODO: replace with add_filter('not_from_this_plugin') if upstream PR accepted/released
+        # https://github.com/spacetelescope/jdaviz/pull/2239
+        def not_from_binning_plugin(data):
+            return data.meta.get('Plugin', None) != self.__class__.__name__
+        self.dataset.add_filter(not_from_binning_plugin)
+
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._set_results_viewer)
+        self.hub.subscribe(self, ViewerRemovedMessage, handler=self._set_results_viewer)
+
+    @property
+    def user_api(self):
+        expose = ['dataset', 'ephemeris', 'input_lc', 'add_results', 'bin']
+        return PluginUserApi(self, expose=expose)
+
+    @property
+    def ephemeris_plugin(self):
+        return self.ephemeris.ephemeris_plugin
+
+    @property
+    def input_lc(self):
+        return self.ephemeris.get_data_for_dataset(self.dataset)
+
+    @property
+    def marks(self):
+        marks = {}
+        for id, viewer in self.app._viewer_store.items():
+            for mark in viewer.figure.marks:
+                if isinstance(mark, LivePreviewBinning):
+                    marks[id] = mark
+                    break
+            else:
+                mark = LivePreviewBinning(viewer, visible=self.plugin_opened)
+                viewer.figure.marks = viewer.figure.marks + [mark]
+                marks[id] = mark
+        return marks
+
+    def _clear_marks(self):
+        for mark in self.marks.values():
+            if mark.visible:
+                mark.clear()
+                mark.visible = False
+
+    @observe("dataset_selected", "ephemeris_selected")
+    def _set_default_results_label(self, event={}):
+        '''Generate a label and set the results field to that value'''
+        if not hasattr(self, 'ephemeris'):
+            return
+        label = f"binned {self.dataset_selected}"
+        if self.ephemeris_selected not in self.ephemeris._manual_options:
+            label += f":{self.ephemeris_selected}"
+        self.results_label_default = label
+
+    @observe("ephemeris_selected")
+    def _set_results_viewer(self, event={}):
+        if not hasattr(self, 'ephemeris'):
+            return
+
+        def viewer_filter(viewer):
+            if self.ephemeris_selected in self.ephemeris._manual_options:
+                return viewer.reference == _default_time_viewer_reference_name
+            if 'flux-vs-phase:' not in viewer.reference:
+                # ephemeris selected, but no active phase viewers
+                return False
+            return viewer.reference.split('flux-vs-phase:')[1] == self.ephemeris_selected
+
+        self.add_results.viewer.filters = [viewer_filter]
+
+    @observe('show_live_preview', 'plugin_opened',
+             'dataset_selected', 'ephemeris_selected',
+             'n_bins')
+    def _live_update(self, event={}):
+        if not self.show_live_preview or not self.plugin_opened:
+            self._clear_marks()
+            return
+
+        lc = self.bin(add_data=False)
+
+        if self.ephemeris_selected == 'No ephemeris':
+            ref_time = lc.meta.get('reference_time', 0)
+            times = lc.time - ref_time
+        else:
+            times = lc.time
+
+        for viewer_id, mark in self.marks.items():
+            if self.ephemeris_selected == 'No ephemeris':
+                # TODO: change to be visible in all viewers, but re-phasing on ephemeris change using markers logic
+                visible = viewer_id == 'lcviz-0'  # TODO: fix this to be general and not rely on ugly id
+            else:
+                # TODO: re-bin on change to selected ephemeris
+                visible = viewer_id.split(':')[-1] == self.ephemeris_selected
+
+            if visible:
+                mark.update_xy(times.value, lc.flux.value)
+            else:
+                mark.clear()
+            mark.visible = visible
+
+    def bin(self, add_data=True):
+        lc = self.input_lc
+        # TODO: this is raising separate errors in time and phase-space, likely because of
+        # roundtripping issues in the translators
+        lc = lc.bin(time_bin_size=(lc.time[-1]-lc.time[0]).value/self.n_bins)
+
+        if add_data:
+            # add data to the collection/viewer
+            self.add_results.add_results_from_plugin(lc)
+
+        return lc
+
+    def vue_apply(self, event={}):
+        self.bin(add_data=True)

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -130,15 +130,15 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
             return
 
         lc = self.bin(add_data=False)
+        # TODO: remove the need for this (inconsistent quantity vs value setting in lc object)
+        lc_time = getattr(lc.time, 'value', lc.time)
 
         if self.ephemeris_selected == 'No ephemeris':
             ref_time = lc.meta.get('reference_time', 0)
             ref_time = getattr(ref_time, 'value', ref_time)
-            times = lc.time - ref_time
+            times = lc_time - ref_time
         else:
-            times = lc.time
-        # TODO: remove the need for this (inconsistent quantity vs value setting in lc object)
-        times = getattr(times, 'value', times)
+            times = lc_time
 
         for viewer_id, mark in self.marks.items():
             if self.ephemeris_selected == 'No ephemeris':

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -212,6 +212,8 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
                 pv = self.app.get_viewer(viewer_id)
                 phase_comp_lbl = self.app._jdaviz_helper._phase_comp_lbl(self.ephemeris_selected)
                 pv.state.x_att = self.app._jdaviz_helper._component_ids[phase_comp_lbl]
+                # by resetting x_att, the preview marks may have dissappeared
+                self._live_update()
 
         return lc
 

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -36,6 +36,7 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
     * :meth:`bin`
     """
     template_file = __file__, "binning.vue"
+    uses_active_status = Bool(True).tag(sync=True)
 
     show_live_preview = Bool(True).tag(sync=True)
 
@@ -85,7 +86,7 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
                     marks[id] = mark
                     break
             else:
-                mark = LivePreviewBinning(viewer, visible=self.plugin_opened)
+                mark = LivePreviewBinning(viewer, visible=self.is_active)
                 viewer.figure.marks = viewer.figure.marks + [mark]
                 marks[id] = mark
         return marks
@@ -121,11 +122,11 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
 
         self.add_results.viewer.filters = [viewer_filter]
 
-    @observe('show_live_preview', 'plugin_opened',
+    @observe('show_live_preview', 'is_active',
              'dataset_selected', 'ephemeris_selected',
              'n_bins')
     def _live_update(self, event={}):
-        if not self.show_live_preview or not self.plugin_opened:
+        if not self.show_live_preview or not self.is_active:
             self._clear_marks()
             return
 
@@ -161,7 +162,7 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
             mark.visible = visible
 
     def _on_ephemeris_update(self, msg):
-        if not self.show_live_preview or not self.plugin_opened:
+        if not self.show_live_preview or not self.is_active:
             return
 
         if msg.ephemeris_label != self.ephemeris_selected:

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -2,6 +2,9 @@
   <j-tray-plugin
     description='Bin in time or phase-space.'
     :link="'https://lcviz.readthedocs.io/en/'+vdocs+'/plugins.html#binning'"
+    :uses_active_status="uses_active_status"
+    @plugin-ping="plugin_ping($event)"
+    :keep_active.sync="keep_active"
     :popout_button="popout_button">
 
     <v-row>

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -54,6 +54,15 @@
       </v-text-field>
     </v-row>
 
+    <v-row v-if="ephemeris_selected !== 'No ephemeris'">
+      <v-switch
+        v-model="map_to_times"
+        label="Map to times"
+        hint="Whether to map the phase-binned data onto the full time-range."
+        persistent-hint
+      ></v-switch>
+    </v-row>
+
 
     <plugin-add-results
       :label.sync="results_label"

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -1,0 +1,73 @@
+<template>
+  <j-tray-plugin
+    description='Bin in time or phase-space.'
+    :link="'https://lcviz.readthedocs.io/en/'+vdocs+'/plugins.html#binning'"
+    :popout_button="popout_button">
+
+    <v-row>
+      <v-expansion-panels popout>
+        <v-expansion-panel>
+          <v-expansion-panel-header v-slot="{ open }">
+            <span style="padding: 6px">Settings</span>
+          </v-expansion-panel-header>
+          <v-expansion-panel-content>
+            <v-row>
+              <v-switch
+                v-model="show_live_preview"
+                label="Show live preview"
+                hint="Whether to show live preview of binning options."
+                persistent-hint
+              ></v-switch>
+            </v-row>
+          </v-expansion-panel-content>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-row>
+
+    <plugin-dataset-select
+      :items="dataset_items"
+      :selected.sync="dataset_selected"
+      :show_if_single_entry="false"
+      label="Data"
+      hint="Select the light curve as input."
+    />
+
+    <plugin-ephemeris-select
+      :items="ephemeris_items"
+      :selected.sync="ephemeris_selected"
+      :show_if_single_entry="false"
+      label="Ephemeris"
+      hint="Select the phase-folding as input."
+    />
+
+    <v-row>
+      <v-text-field
+        label="N Bins"
+        type="number"
+        v-model.number="n_bins"
+        :step="10"
+        :rules="[() => n_bins !== '' || 'This field is required',
+                 () => n_bins > 0 || 'Number of bins must be positive']"
+        hint="Number of bins."
+        persistent-hint
+      >
+      </v-text-field>
+    </v-row>
+
+
+    <plugin-add-results
+      :label.sync="results_label"
+      :label_default="results_label_default"
+      :label_auto.sync="results_label_auto"
+      :label_invalid_msg="results_label_invalid_msg"
+      :label_overwrite="results_label_overwrite"
+      label_hint="Label for the binned data."
+      :add_to_viewer_items="add_to_viewer_items"
+      :add_to_viewer_selected.sync="add_to_viewer_selected"
+      action_label="Bin"
+      action_tooltip="Bin data"
+      @click:action="apply"
+    ></plugin-add-results>
+
+  </j-tray-plugin>
+</template>

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -54,16 +54,6 @@
       </v-text-field>
     </v-row>
 
-    <v-row v-if="ephemeris_selected !== 'No ephemeris'">
-      <v-switch
-        v-model="map_to_times"
-        label="Map to times"
-        hint="Whether to map the phase-binned data onto the full time-range."
-        persistent-hint
-      ></v-switch>
-    </v-row>
-
-
     <plugin-add-results
       :label.sync="results_label"
       :label_default="results_label_default"

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -5,6 +5,7 @@ from jdaviz.configs.imviz.plugins.coords_info import CoordsInfo
 from jdaviz.core.registries import tool_registry
 
 from lcviz.viewers import TimeScatterView, PhaseScatterView
+from lcviz.events import ViewerRenamedMessage
 
 
 __all__ = ['CoordsInfo']
@@ -14,6 +15,16 @@ __all__ = ['CoordsInfo']
 class CoordsInfo(CoordsInfo):
     _supported_viewer_classes = (TimeScatterView, PhaseScatterView)
     _viewer_classes_with_marker = (TimeScatterView, PhaseScatterView)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # TODO: move to jdaviz if/once viewer renaming supported
+        self.hub.subscribe(self, ViewerRenamedMessage,
+                           handler=self._viewer_renamed)
+
+    def _viewer_renamed(self, msg):
+        self._marks[msg.new_viewer_ref] = self._marks.pop(msg.old_viewer_ref)
 
     def update_display(self, viewer, x, y):
         self._dict = {}

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -2,7 +2,6 @@ import numpy as np
 from astropy.time import Time
 from traitlets import Bool, Float, List, Unicode, observe
 
-from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
 from glue.core.message import DataCollectionAddMessage
 from jdaviz.core.custom_traitlets import FloatHandleEmpty

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -14,7 +14,7 @@ from jdaviz.core.user_api import PluginUserApi
 
 from lightkurve import periodogram, FoldedLightCurve
 
-from lcviz.events import EphemerisComponentChangedMessage
+from lcviz.events import EphemerisComponentChangedMessage, EphemerisChangedMessage
 from lcviz.template_mixin import EditableSelectPluginComponent
 from lcviz.viewers import PhaseScatterView
 
@@ -390,6 +390,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
 
         self._ephemerides[component] = existing_ephem
         self._update_all_phase_arrays(component=component)
+        self.hub.broadcast(EphemerisChangedMessage(ephemeris_label=component,
+                                                   sender=self))
         return existing_ephem
 
     @observe('period', 'dpdt', 't0', 'wrap_at')

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -322,6 +322,16 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         self._ephemerides[new_lbl] = self._ephemerides.pop(old_lbl, {})
         if self._phase_viewer_id(old_lbl) in self.app.get_viewer_ids():
             self.app._rename_viewer(self._phase_viewer_id(old_lbl), self._phase_viewer_id(new_lbl))
+
+        # update metadata entries so that they can be used for filtering applicable entries in
+        # data menus
+        for dc_item in self.app.data_collection:
+            if dc_item.meta.get('_LCVIZ_EPHEMERIS', {}).get('ephemeris', None) == old_lbl:
+                dc_item.meta['_LCVIZ_EPHEMERIS']['ephemeris'] = new_lbl
+        for data_item in self.app.state.data_items:
+            if data_item.get('meta', {}).get('_LCVIZ_EPHEMERIS', {}).get('ephemeris', None) == old_lbl:  # noqa
+                data_item['meta']['_LCVIZ_EPHEMERIS']['ephemeris'] = new_lbl
+
         self._check_if_phase_viewer_exists()
         self.hub.broadcast(EphemerisComponentChangedMessage(old_lbl=old_lbl, new_lbl=new_lbl,
                                                             sender=self))

--- a/lcviz/plugins/flatten/flatten.py
+++ b/lcviz/plugins/flatten/flatten.py
@@ -10,6 +10,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.marks import LivePreviewTrend, LivePreviewFlattened
+from lcviz.utils import data_not_folded
 from lcviz.viewers import TimeScatterView, PhaseScatterView
 from lcviz.parsers import _data_with_reftime
 
@@ -53,6 +54,9 @@ class Flatten(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # do not support flattening data in phase-space
+        self.dataset.add_filter(data_not_folded)
 
         # marks do not exist for the new viewer, so force another update to compute and draw
         # those marks

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -9,6 +9,8 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin, SelectPluginComponent, PlotMixin)
 from jdaviz.core.user_api import PluginUserApi
 
+from lcviz.utils import data_not_folded
+
 
 __all__ = ['FrequencyAnalysis']
 
@@ -53,6 +55,9 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
         super().__init__(*args, **kwargs)
 
         self._ignore_auto_update = False
+
+        # do not support data only in phase-space
+        self.dataset.add_filter(data_not_folded)
 
         self.method = SelectPluginComponent(self,
                                             items='method_items',

--- a/lcviz/template_mixin.py
+++ b/lcviz/template_mixin.py
@@ -1,10 +1,17 @@
+from functools import cached_property
+from traitlets import List, Unicode
+from ipyvuetify import VuetifyTemplate
+from glue.core import HubListener
+from glue.core.data import Data
+
 import jdaviz
 from jdaviz.core.events import SnackbarMessage
-from jdaviz.core.template_mixin import SelectPluginComponent
+from jdaviz.core.template_mixin import SelectPluginComponent, DatasetSelect
 from jdaviz.core.template_mixin import ViewerSelect
-from lcviz.events import ViewerRenamedMessage
+from lcviz.events import ViewerRenamedMessage, EphemerisComponentChangedMessage
 
-__all__ = ['EditableSelectPluginComponent']
+__all__ = ['EditableSelectPluginComponent',
+           'EphemerisSelect', 'EphemerisSelectMixin']
 
 
 # TODO: remove this if/when jdaviz supports renaming viewers natively
@@ -101,3 +108,139 @@ class EditableSelectPluginComponent(SelectPluginComponent):
         if was_selected:
             self.selected = new
         self._on_rename(old, new)
+
+
+class EphemerisSelect(SelectPluginComponent):
+    """
+    Plugin select for ephemeris components defined by the Ephemeris plugin.
+
+    Useful API methods/attributes:
+
+    * :meth:`~SelectPluginComponent.choices`
+    * ``selected``
+    * :attr:`selected_obj`
+    * :meth:`~SelectPluginComponent.select_default`
+    """
+
+    """
+    Traitlets (in the object, custom traitlets in the plugin):
+
+    * ``items`` (list of dicts with keys: label)
+    * ``selected`` (string)
+
+    Properties (in the object only):
+
+    * ``selected_obj``
+
+    To use in a plugin:
+
+    * create traitlets with default values
+    * register with all the automatic logic in the plugin's init by passing the string names
+      of the respective traitlets
+    * use component in plugin template (see below)
+    * refer to properties above based on the interally stored reference to the
+      instantiated object of this component
+
+    Example template (label and hint are optional)::
+
+      <plugin-ephemeris-select
+        :items="ephemeris_items"
+        :selected.sync="ephemeris_selected"
+        label="Ephemeris"
+        hint="Select ephemeris."
+      />
+
+    """
+    def __init__(self, plugin, items, selected,
+                 default_text='No ephemeris', manual_options=[],
+                 default_mode='first'):
+        """
+        Parameters
+        ----------
+        plugin
+            the parent plugin object
+        items : str
+            the name of the items traitlet defined in ``plugin``
+        selected : str
+            the name of the selected traitlet defined in ``plugin``
+        default_text : str or None
+            the text to show for no selection.  If not provided or None, no entry will be provided
+            in the dropdown for no selection.
+        manual_options: list
+            list of options to provide that are not automatically populated by ephemerides.  If
+            ``default`` text is provided but not in ``manual_options`` it will still be included as
+            the first item in the list.
+        """
+        super().__init__(plugin, items=items, selected=selected,
+                         default_text=default_text, manual_options=manual_options,
+                         default_mode=default_mode)
+        self.hub.subscribe(self, EphemerisComponentChangedMessage,
+                           handler=self._ephem_component_change)
+
+    @cached_property
+    def ephemeris_plugin(self):
+        return self.app._jdaviz_helper.plugins.get('Ephemeris', None)
+
+    @cached_property
+    def selected_obj(self):
+        if self.selected in self._manual_options:
+            return None
+        return self.ephemeris_plugin.ephemerides.get(self.selected, None)
+
+    def get_data_for_dataset(self, dataset, ycomp='flux'):
+        if not isinstance(dataset, DatasetSelect):
+            raise ValueError("dataset must be DatasetSelect object")
+        if self.selected in self._manual_options:
+            return dataset.selected_obj
+        return self.ephemeris_plugin.get_data(dataset.selected, self.selected)
+
+    def _ephem_component_change(self, msg=None):
+        type = getattr(msg, 'type', None)
+        if type == 'remove' and msg.old_lbl in self.choices:
+            self.items = [item for item in self.items if item['label'] != msg.old_lbl]
+            self._apply_default_selection()
+        elif type == 'rename' and msg.old_lbl in self.choices:
+            was_selected = self.selected == msg.old_lbl
+            self.items = [item if item['label'] != msg.old_lbl else {'label': msg.new_lbl}
+                          for item in self.items]
+            if was_selected:
+                self.selected = msg.new_lbl
+        elif type == 'add' and msg.new_lbl not in self.choices:
+            self.items = self.items + [{'label': msg.new_lbl}]
+        else:
+            # something might be out of sync, build from scratch
+            manual_items = [{'label': label} for label in self.manual_options]
+            self.items = manual_items + [{'label': component}
+                                         for component in self.ephemeris_plugin.ephemerides.keys()]
+            self._apply_default_selection()
+
+
+class EphemerisSelectMixin(VuetifyTemplate, HubListener):
+    """
+    Applies the EphemerisSelect component as a mixin in the base plugin.  This
+    automatically adds traitlets as well as new properties to the plugin with minimal
+    extra code.  For multiple instances or custom traitlet names/defaults, use the
+    component instead.
+
+    To use in a plugin:
+
+    * add ``EphemerisSelectMixin`` as a mixin to the class
+    * use the traitlets available from the plugin or properties/methods available from
+      ``plugin.ephemeris``.
+
+    Example template (label and hint are optional)::
+
+      <plugin-ephemeris-select
+        :items="ephemeris_items"
+        :selected.sync="ephemeris_selected"
+        label="Ephemeris"
+        hint="Select ephemeris."
+      />
+
+    """
+    ephemeris_items = List().tag(sync=True)
+    ephemeris_selected = Unicode().tag(sync=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ephemeris = EphemerisSelect(self, 'ephemeris_items', 'ephemeris_selected')

--- a/lcviz/template_mixin.py
+++ b/lcviz/template_mixin.py
@@ -187,7 +187,7 @@ class EphemerisSelect(SelectPluginComponent):
         return self.ephemeris_plugin.ephemerides.get(self.selected, None)
 
     def get_data_for_dataset(self, dataset, ycomp='flux'):
-        if not isinstance(dataset, DatasetSelect):
+        if not isinstance(dataset, DatasetSelect):  # pragma: no cover
             raise ValueError("dataset must be DatasetSelect object")
         if self.selected in self._manual_options:
             return dataset.selected_obj

--- a/lcviz/template_mixin.py
+++ b/lcviz/template_mixin.py
@@ -2,7 +2,6 @@ from functools import cached_property
 from traitlets import List, Unicode
 from ipyvuetify import VuetifyTemplate
 from glue.core import HubListener
-from glue.core.data import Data
 
 import jdaviz
 from jdaviz.core.events import SnackbarMessage

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -27,14 +27,23 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     ephem.period = 1.2345
     pv = ephem.create_phase_viewer()
 
-    assert b.ephemeris == 'No ephemeris'
-    assert len(_get_marks_from_viewer(tv)) == 1
-    assert len(_get_marks_from_viewer(pv)) == 0
+    with b.as_active():
+        assert b.ephemeris == 'No ephemeris'
+        assert len(_get_marks_from_viewer(tv)) == 1
+        assert len(_get_marks_from_viewer(pv)) == 0
+        assert b._obj.ephemeris_dict == {}
 
-    b.bin(add_data=True)
+        # update ephemeris will force re-phasing
+        ephem.period = 1.111
 
-    b.ephemeris = 'default'
-    assert len(_get_marks_from_viewer(tv)) == 0
-    assert len(_get_marks_from_viewer(pv)) == 1
+        b.bin(add_data=True)
 
-    b.bin(add_data=True)
+        b.ephemeris = 'default'
+        assert len(_get_marks_from_viewer(tv)) == 0
+        assert len(_get_marks_from_viewer(pv)) == 1
+        assert len(b._obj.ephemeris_dict.keys()) > 0
+
+        # update ephemeris will force re-binning
+        ephem.period = 1.222
+
+        b.bin(add_data=True)

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -10,7 +10,7 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
 
     b = helper.plugins['Binning']
-    b.open_in_tray()
+    b._obj.plugin_opened = True
     ephem = helper.plugins['Ephemeris']
     ephem.period = 1.2345
     pv = ephem.create_phase_viewer()

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -5,6 +5,18 @@ def _get_marks_from_viewer(viewer, cls=(LivePreviewBinning)):
     return [m for m in viewer.figure.marks if isinstance(m, cls) and m.visible]
 
 
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    binning = lcviz.plugins['Binning']
+    binning.n_bins = 150
+    binned_lc = binning.bin(add_data=True)
+    print(binned_lc)
+
+
 def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -19,6 +19,8 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     assert len(_get_marks_from_viewer(tv)) == 1
     assert len(_get_marks_from_viewer(pv)) == 0
 
+    b.bin(add_data=True)
+
     b.ephemeris = 'default'
     assert len(_get_marks_from_viewer(tv)) == 0
     assert len(_get_marks_from_viewer(pv)) == 1

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -1,0 +1,26 @@
+from lcviz.marks import LivePreviewBinning
+
+
+def _get_marks_from_viewer(viewer, cls=(LivePreviewBinning)):
+    return [m for m in viewer.figure.marks if isinstance(m, cls) and m.visible]
+
+
+def test_plugin_binning(helper, light_curve_like_kepler_quarter):
+    helper.load_data(light_curve_like_kepler_quarter)
+    tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+
+    b = helper.plugins['Binning']
+    b.open_in_tray()
+    ephem = helper.plugins['Ephemeris']
+    ephem.period = 1.2345
+    pv = ephem.create_phase_viewer()
+
+    assert b.ephemeris == 'No ephemeris'
+    assert len(_get_marks_from_viewer(tv)) == 1
+    assert len(_get_marks_from_viewer(pv)) == 0
+
+    b.ephemeris = 'default'
+    assert len(_get_marks_from_viewer(tv)) == 0
+    assert len(_get_marks_from_viewer(pv)) == 1
+
+    b.bin(add_data=True)

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -68,5 +68,5 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     ephem._obj.vue_adopt_period_at_max_power()
     assert ephem.period != 2
 
-    # test coverage for non-zero dpdt
-    ephem.dpdt = 0.00001
+    # test that non-zero dpdt does not crash
+    ephem.dpdt = 0.005

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -52,7 +52,7 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert ephem.period == 3.14
     assert ephem.ephemeris['period'] == 3.14
     # modify the ephemeris of the NON-selected ephemeris component
-    ephem.update_ephemeris(component='default', period=2)
+    ephem.update_ephemeris(ephem_component='default', period=2)
     assert ephem.period == 3.14
     assert ephem.ephemerides['default']['period'] == 2
 

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -70,7 +70,7 @@ class LightCurveHandler:
     def to_data(self, obj, reference_time=None):
         is_folded = isinstance(obj, FoldedLightCurve)
         time = obj.time_original if is_folded and hasattr(obj, 'time_original') else obj.time
-        time_coord = TimeCoordinates(time)
+        time_coord = TimeCoordinates(time, reference_time=reference_time)
         data = Data(coords=time_coord)
 
         if hasattr(obj, 'label'):

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -69,10 +69,8 @@ class LightCurveHandler:
 
     def to_data(self, obj, reference_time=None):
         is_folded = isinstance(obj, FoldedLightCurve)
-        time = obj.time_original if is_folded else obj.time
-        time_coord = TimeCoordinates(
-            time, reference_time=reference_time
-        )
+        time = obj.time_original if is_folded and hasattr(obj, 'time_original') else obj.time
+        time_coord = TimeCoordinates(time)
         data = Data(coords=time_coord)
 
         if hasattr(obj, 'label'):
@@ -154,6 +152,9 @@ class LightCurveHandler:
             component_ids.remove(skip_comp)
 
         for component_id in component_ids:
+            if component_id.label in names:
+                # avoid duplicate column
+                continue
             component = data.get_component(component_id)
 
             values = component.data[glue_mask]

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -100,7 +100,10 @@ class LightCurveHandler:
 
             data[cid] = component_data
             if hasattr(component_data, 'unit'):
-                data.get_component(cid).units = str(component_data.unit)
+                try:
+                    data.get_component(cid).units = str(component_data.unit)
+                except KeyError:
+                    continue
 
         data.meta.update({'uncertainty_type': 'std'})
 

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -102,7 +102,7 @@ class LightCurveHandler:
             if hasattr(component_data, 'unit'):
                 try:
                     data.get_component(cid).units = str(component_data.unit)
-                except KeyError:
+                except KeyError:  # pragma: no cover
                     continue
 
         data.meta.update({'uncertainty_type': 'std'})

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -15,7 +15,7 @@ from lightkurve import (
     LightCurve, KeplerLightCurve, TessLightCurve, FoldedLightCurve
 )
 
-__all__ = ['TimeCoordinates', 'LightCurveHandler']
+__all__ = ['TimeCoordinates', 'LightCurveHandler', 'data_not_folded']
 
 
 class TimeCoordinates(Coordinates):
@@ -205,3 +205,8 @@ class KeplerLightCurveHandler(LightCurveHandler):
 class TessLightCurveHandler(LightCurveHandler):
     # Works the same as LightCurve
     pass
+
+
+# plugin component filters
+def data_not_folded(data):
+    return data.meta.get('_LCVIZ_EPHEMERIS', None) is None

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -91,6 +91,11 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
 
         return data
 
+    def _apply_layer_defaults(self, layer_state):
+        if getattr(layer_state.layer, 'meta', {}).get('Plugin', None) == 'Binning':
+            # increased size of binned results, by default
+            layer_state.size = 5
+
     def set_plot_axes(self):
         # set which components should be plotted
         dc = self.jdaviz_app.data_collection

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -227,4 +227,4 @@ class PhaseScatterView(TimeScatterView):
         if ephem is None:
             raise ValueError("must have ephemeris plugin loaded to convert")
 
-        return ephem.times_to_phases(times, component=self.ephemeris_component)
+        return ephem.times_to_phases(times, ephem_component=self.ephemeris_component)


### PR DESCRIPTION
This PR implements a binning plugin (wrapping existing `lightkurve` binning functionality), supporting binning in either time or phase-space, along with a live-preview that works in conjunction with changes to the underlying ephemeris (when phase-binning, the binning is recomputed with any change to the ephemeris that dictates that phase-folding).  Once loaded into the app, the binned data remain fixed (and with https://github.com/spacetelescope/jdaviz/pull/2312 would only be available to load in the respective viewer).

This PR currently only exposes the number of bins as an input parameter, but we might want to consider (now or as a follow-up effort) the ability to optionally provide a bin width in time/phase units instead.

Support for having live-updating binning in the data-collection object might be considered in the future, but is out-of-scope for now.


https://github.com/spacetelescope/lcviz/assets/877591/b183c3bb-9c31-4e9e-8125-e8111e800c8c

~There seems to be a slight bug with the reference time when the time-binned data is actually applied and then phased (the phasing in the preview and the finalized data appears different).  I'm not sure if that is introduced here or an existing bug that this uncovers.~

The change in color when adding the time-binned data to the second viewer is likely an upstream bug.

* [plugin docs](https://lcviz--28.org.readthedocs.build/en/28/plugins.html#binning)
* [plugin API docs](https://lcviz--28.org.readthedocs.build/en/28/api/lcviz.plugins.binning.binning.Binning.html)