### PR TITLE
Load multiple data with different start times

### DIFF
--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -5,7 +5,6 @@ import os
 from lightkurve import LightCurve
 
 from glue.core.link_helpers import LinkSame
-from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink
 from jdaviz.core.helpers import ConfigHelper
 from lcviz.events import ViewerRenamedMessage
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -5,6 +5,7 @@ import os
 from lightkurve import LightCurve
 
 from glue.core.link_helpers import LinkSame
+from glue.plugins.wcs_autolinking.wcs_autolinking import WCSLink
 from jdaviz.core.helpers import ConfigHelper
 from lcviz.events import ViewerRenamedMessage
 
@@ -87,13 +88,16 @@ def _link_new_data(app, reference_data=None, data_to_be_linked=None):
     ref_data = dc[reference_data] if reference_data else dc[0]
     linked_data = dc[data_to_be_linked] if data_to_be_linked else dc[-1]
 
-    ref_data_comps = {str(comp): comp for comp in ref_data.components}
-    linked_data_comps = {str(comp): comp for comp in linked_data.components}
+    new_link = LinkSame(
+        cid1=ref_data.world_component_ids[0],
+        cid2=linked_data.world_component_ids[0],
+        data1=ref_data,
+        data2=linked_data,
+        labels1=ref_data.label,
+        labels2=linked_data.label
+    )
 
-    links = [LinkSame(comp, linked_data_comps[comp_name])
-             for comp_name, comp in ref_data_comps.items() if comp_name in linked_data_comps]
-
-    dc.add_link(links)
+    dc.add_link(new_link)
     return
 
 

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -43,17 +43,7 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     if flux_origin is not None:
         new_data_label += f'[{flux_origin}]'
 
-    # grab the first-found reference time in the data collection:
-    ff_reference_time = None
-    for existing_data in app.data_collection:
-        if hasattr(existing_data, 'meta') and 'reference_time' in existing_data.meta:
-            ff_reference_time = existing_data.meta.get('reference_time', None)
-            if ff_reference_time is not None:
-                break
-
-    # convert to glue Data manually, so we may edit the `dt` component if necessary:
-    handler, _ = data_translator.get_handler_for(light_curve)
-    data = handler.to_data(light_curve, reference_time=ff_reference_time)
+    data = _data_with_reftime(app, light_curve)
     app.add_data(data, new_data_label)
 
     if show_in_viewer:
@@ -64,3 +54,17 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         if ephem_plugin is not None:
             for viewer_id in ephem_plugin._obj.phase_viewer_ids:
                 app.add_data_to_viewer(viewer_id, new_data_label)
+
+
+def _data_with_reftime(app, light_curve):
+    # grab the first-found reference time in the data collection:
+    ff_reference_time = None
+    for existing_data in app.data_collection:
+        if hasattr(existing_data, 'meta') and 'reference_time' in existing_data.meta:
+            ff_reference_time = existing_data.meta.get('reference_time', None)
+            if ff_reference_time is not None:
+                break
+
+    # convert to glue Data manually, so we may edit the `dt` component if necessary:
+    handler, _ = data_translator.get_handler_for(light_curve)
+    return handler.to_data(light_curve, reference_time=ff_reference_time)

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -1,6 +1,6 @@
 import os
 from astropy.io import fits
-from glue.core.link_helpers import LinkSame
+from glue.config import data_translator
 from jdaviz.core.registries import data_parser_registry
 from lightkurve import LightCurve, KeplerLightCurve, TessLightCurve
 from lightkurve.io.detect import detect_filetype
@@ -43,13 +43,18 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     if flux_origin is not None:
         new_data_label += f'[{flux_origin}]'
 
-    app.add_data(light_curve, new_data_label)
-    dc = app.data_collection
-    if len(dc) > 1:
-        # then we need to link this light curve back to the first
-        dc0_comps = {str(comp): comp for comp in dc[0].components}
-        new_links = [LinkSame(dc0_comps.get(str(new_comp)), new_comp) for new_comp in dc[-1].components]  # noqa
-        dc.set_links(new_links)
+    # grab the first-found reference time in the data collection:
+    ff_reference_time = None
+    for existing_data in app.data_collection:
+        if hasattr(existing_data, 'meta') and 'reference_time' in existing_data.meta:
+            ff_reference_time = existing_data.meta.get('reference_time', None)
+            if ff_reference_time is not None:
+                break
+
+    # convert to glue Data manually, so we may edit the `dt` component if necessary:
+    handler, _ = data_translator.get_handler_for(light_curve)
+    data = handler.to_data(light_curve, reference_time=ff_reference_time)
+    app.add_data(data, new_data_label)
 
     if show_in_viewer:
         app.add_data_to_viewer(time_viewer_reference_name, new_data_label)

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -72,6 +72,9 @@ class CoordsInfo(CoordsInfo):
 
             scatter = lyr.scatter
             lyr_x, lyr_y = scatter.x, scatter.y
+            if not len(lyr_x):
+                continue
+
             # NOTE: unlike specviz which determines the closest point in x per-layer,
             # this determines the closest point in x/y per-layer in pixel-space
             # (making it easier to get the snapping point into shallow eclipses, etc)

--- a/lcviz/plugins/flatten/flatten.py
+++ b/lcviz/plugins/flatten/flatten.py
@@ -11,7 +11,7 @@ from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.marks import LivePreviewTrend, LivePreviewFlattened
 from lcviz.viewers import TimeScatterView, PhaseScatterView
-
+from lcviz.parsers import _data_with_reftime
 
 __all__ = ['Flatten']
 
@@ -142,7 +142,8 @@ class Flatten(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
 
         if add_data:
             # add data to the collection/viewer
-            self.add_results.add_results_from_plugin(output_lc)
+            data = _data_with_reftime(self.app, output_lc)
+            self.add_results.add_results_from_plugin(data)
 
         return output_lc, trend_lc
 

--- a/lcviz/state.py
+++ b/lcviz/state.py
@@ -33,3 +33,28 @@ class ScatterViewerState(ScatterViewerState):
 
     def _reset_y_limits(self, *event):
         self._reset_att_limits('y')
+
+    def reset_limits(self, *event):
+        x_min, x_max = np.inf, -np.inf
+        y_min, y_max = np.inf, -np.inf
+
+        for layer in self.layers:
+            if not layer.visible:
+                continue
+
+            x_data = layer.layer.data.get_data(self.x_att)
+            y_data = layer.layer.data.get_data(self.y_att)
+
+            x_min = min(x_min, np.nanmin(x_data))
+            x_max = max(x_max, np.nanmax(x_data))
+            y_min = min(y_min, np.nanmin(y_data))
+            y_max = max(y_max, np.nanmax(y_data))
+
+        with delay_callback(self, 'x_min', 'x_max', 'y_min', 'y_max'):
+            self.x_min = x_min
+            self.x_max = x_max
+            self.y_min = y_min
+            self.y_max = y_max
+            # We need to adjust the limits in here to avoid triggering all
+            # the update events then changing the limits again.
+            self._adjust_limits_aspect()

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -4,7 +4,9 @@ from ipyvue import watch
 
 import os
 from glue.core.coordinates import Coordinates
+from glue.core.component_id import ComponentID
 import numpy as np
+from scipy.interpolate import interp1d
 from astropy import units as u
 from astropy.table import QTable
 from astropy.time import Time
@@ -27,55 +29,35 @@ class TimeCoordinates(Coordinates):
             raise TypeError('values should be a Time instance')
         self._index = np.arange(len(times))
         self._times = times
+        self.unit = unit
 
         # convert to relative time units
-        if reference_time is None:
+        self.reference_time = reference_time
+        if self.reference_time is None:
             self.reference_time = times[0]
-
-        delta_t = (times - self.reference_time).to(unit)
-        self._values = delta_t
+        self._values = (times - self.reference_time).to(unit)
 
         super().__init__(n_dim=1)
 
     @property
     def time_axis(self):
-        """
-        Returns
-        -------
-        """
         return self._times
 
-    @property
-    def world_axis_units(self):
-        return tuple(self._values.unit.to_string('vounit'))
-
     def world_to_pixel_values(self, *world):
-        """
-        Parameters
-        ----------
-        world
-        Returns
-        -------
-        """
         if len(world) > 1:
             raise ValueError('TimeCoordinates is a 1-d coordinate class '
                              'and only accepts a single scalar or array to convert')
-        return np.interp(world[0], self._values.value, self._index,
-                         left=np.nan, right=np.nan)
+        return interp1d(
+            self._values.value, self._index, fill_value='extrapolate'
+        )(world[0])
 
     def pixel_to_world_values(self, *pixel):
-        """
-        Parameters
-        ----------
-        pixel
-        Returns
-        -------
-        """
         if len(pixel) > 1:
             raise ValueError('SpectralCoordinates is a 1-d coordinate class '
                              'and only accepts a single scalar or array to convert')
-        return np.interp(pixel[0], self._index, self._values.value,
-                         left=np.nan, right=np.nan)
+        return interp1d(
+            self._index, self._values.value, fill_value='extrapolate'
+        )(pixel[0])
 
 
 __all__ = ['LightCurveHandler', 'enable_hot_reloading']
@@ -83,28 +65,36 @@ __all__ = ['LightCurveHandler', 'enable_hot_reloading']
 
 @data_translator(LightCurve)
 class LightCurveHandler:
+    lc_component_ids = {}
 
-    def to_data(self, obj):
-        time_coord = TimeCoordinates(obj.time)
-        delta_t = (obj.time - obj.time[0]).to(u.d)
+    def to_data(self, obj, reference_time=None):
+        time_coord = TimeCoordinates(
+            obj.time, reference_time=reference_time
+        )
         data = Data(coords=time_coord)
 
         if hasattr(obj, 'label'):
             data.label = obj.label
 
         data.meta.update(obj.meta)
-        data.meta.update({"reference_time": obj.time[0]})
-
-        data['dt'] = delta_t
-        data.get_component('dt').units = str(delta_t.unit)
+        data.meta.update(
+            {"reference_time": time_coord.reference_time}
+        )
+        data['dt'] = (obj.time - time_coord.reference_time).to(time_coord.unit)
+        data.get_component('dt').units = str(time_coord.unit)
 
         # LightCurve is a subclass of astropy TimeSeries, so
         # collect all other columns in the TimeSeries:
         for component_label in obj.colnames:
+
+            if component_label not in self.lc_component_ids:
+                self.lc_component_ids[component_label] = ComponentID(component_label)
+            cid = self.lc_component_ids[component_label]
+
             component_data = getattr(obj, component_label)
-            data[component_label] = component_data
+            data[cid] = component_data
             if hasattr(component_data, 'unit'):
-                data.get_component(component_label).units = str(component_data.unit)
+                data.get_component(cid).units = str(component_data.unit)
 
         data.meta.update({'uncertainty_type': 'std'})
 

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -155,8 +155,9 @@ class LightCurveHandler:
             elif hasattr(component, 'units') and component.units != "None":
                 values = u.Quantity(values, component.units)
 
-            columns.append(values)
-            names.append(component_id.label)
+            if component_id.label not in names:
+                columns.append(values)
+                names.append(component_id.label)
 
         table = QTable(columns, names=names, masked=True, copy=False)
         return LightCurve(table, **kwargs)

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -48,20 +48,38 @@
    "source": [
     "lc_q10 = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=10).download()\n",
     "\n",
-    "def preprocess_lc(lc, window_length=50):\n",
-    "    \"\"\"\n",
-    "    Here we use the lightkurve `flatten` method for roughly detrending\n",
-    "    the light curve. There will be workflows for doing this operation\n",
-    "    through the UI soon.\n",
-    "    \"\"\"\n",
-    "    return lc.flatten(\n",
-    "        window_length=window_length, polyorder=3\n",
-    "    ).remove_nans()\n",
     "\n",
     "lcviz = LCviz()\n",
-    "lcviz.load_data(preprocess_lc(lc_q9), data_label='Q9')\n",
-    "lcviz.load_data(preprocess_lc(lc_q10), data_label='Q10')\n",
+    "lcviz.load_data(lc_q9, data_label='Q9')\n",
+    "lcviz.load_data(lc_q10, data_label='Q10')\n",
     "lcviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d599828c-58c4-42d8-936f-ded63fc34115",
+   "metadata": {},
+   "source": [
+    "Use the `Flatten` plugin to remove low frequency trends from the light curves:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9461fa3c-e213-40d1-8a33-89c8a2c399cd",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "flatten = lcviz.plugins['Flatten']\n",
+    "\n",
+    "n_quarters = len(lcviz.app.data_collection)\n",
+    "\n",
+    "for _ in range(n_quarters):\n",
+    "    # flatten once per dataset:\n",
+    "    flatten.window_length = 50\n",
+    "    flatten.flatten();"
    ]
   },
   {
@@ -98,17 +116,10 @@
     "eph.t0 = (\n",
     "    (morris2017_epoch - reference_time).to_value(time_coord.unit) % eph.period\n",
     ")\n",
-    "# recenter the phase axis with transit at phase=0.5\n",
+    "\n",
+    "# offset phase axis so mid-transit occurs at phase=0.5\n",
     "eph.t0 += 0.5 * eph.period"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a6cae4e2-58b5-4f95-a8bf-75f9c2ef8c01",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -1,26 +1,111 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "45e4a15d-684d-47bc-b1f0-ac17e85afd31",
+   "metadata": {},
+   "source": [
+    "# LCviz\n",
+    "\n",
+    "Load the Kepler 30 minute (\"long\") cadence light curveof HAT-P-11 from Kepler Quarter 9 (in 2011). HAT-P-11 is a K4V host to a transiting hot Neptune with a 4.8 day period, and a stellar rotation period of 29 days."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a21f400f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from lightkurve import search_lightcurve\n",
     "from lcviz import LCviz\n",
     "\n",
-    "lc = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=10).download()\n",
+    "lc_q9 = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=9).download()\n",
     "\n",
     "lcviz = LCviz()\n",
-    "lcviz.load_data(lc)\n",
+    "lcviz.load_data(lc_q9)\n",
     "lcviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d007fb51-89db-4eaa-86a7-ee832e450ede",
+   "metadata": {},
+   "source": [
+    "Load and display a second Kepler quarter in the same viewer. We'll pre-process the light curves by flattening them to remove out-of-transit variability due to stellar rotation:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "8dde219d-c9f1-4967-9437-e0abdcbd32b5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lc_q10 = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=10).download()\n",
+    "\n",
+    "def preprocess_lc(lc, window_length=50):\n",
+    "    \"\"\"\n",
+    "    Here we use the lightkurve `flatten` method for roughly detrending\n",
+    "    the light curve. There will be workflows for doing this operation\n",
+    "    through the UI soon.\n",
+    "    \"\"\"\n",
+    "    return lc.flatten(\n",
+    "        window_length=window_length, polyorder=3\n",
+    "    ).remove_nans()\n",
+    "\n",
+    "lcviz = LCviz()\n",
+    "lcviz.load_data(preprocess_lc(lc_q9), data_label='Q9')\n",
+    "lcviz.load_data(preprocess_lc(lc_q10), data_label='Q10')\n",
+    "lcviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd7f8673-bce1-4712-b768-c4b0b41d798a",
+   "metadata": {},
+   "source": [
+    "Show a phase folded light curve, given the ephemeris for the transiting exoplanet HAT-P-11 b:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6485f1ba-27c2-4021-b818-fa39851a5e78",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "from astropy.time import Time\n",
+    "\n",
+    "# origin on the time axis\n",
+    "time_coord = lcviz.app.data_collection[0].coords\n",
+    "reference_time = time_coord.reference_time\n",
+    "\n",
+    "# literature ephemeris for hot Neptune planet HAT-P-11 b\n",
+    "morris2017_epoch = Time(2454605.89146, format='jd')\n",
+    "morris2017_period = 4.88780258  # days\n",
+    "\n",
+    "# phase the transit light curve\n",
+    "eph = lcviz.plugins['Ephemeris']\n",
+    "eph.period = morris2017_period\n",
+    "eph.t0 = (\n",
+    "    (morris2017_epoch - reference_time).to_value(time_coord.unit) % eph.period\n",
+    ")\n",
+    "# recenter the phase axis with transit at phase=0.5\n",
+    "eph.t0 += 0.5 * eph.period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6cae4e2-58b5-4f95-a8bf-75f9c2ef8c01",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -42,7 +127,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# LCviz\n",
     "\n",
-    "Load the Kepler 30 minute (\"long\") cadence light curveof HAT-P-11 from Kepler Quarter 9 (in 2011). HAT-P-11 is a K4V host to a transiting hot Neptune with a 4.8 day period, and a stellar rotation period of 29 days."
+    "Load the Kepler 30-minute (\"long\") cadence light curve of HAT-P-11 from Kepler Quarter 9 (in 2011). HAT-P-11 is a K4V host to a transiting hot Neptune with a 4.8 day period, and a stellar rotation period of 29 days."
    ]
   },
   {
@@ -19,11 +19,16 @@
    },
    "outputs": [],
    "source": [
+    "import astropy.units as u\n",
+    "from astropy.time import Time\n",
     "from lightkurve import search_lightcurve\n",
+    "\n",
     "from lcviz import LCviz\n",
     "\n",
+    "# Download the light curve from MAST:\n",
     "lc_q9 = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=9).download()\n",
     "\n",
+    "# Load the light curve into LCviz:\n",
     "lcviz = LCviz()\n",
     "lcviz.load_data(lc_q9)\n",
     "lcviz.show()"
@@ -46,9 +51,10 @@
    },
    "outputs": [],
    "source": [
+    "# Download another Kepler quarter:\n",
     "lc_q10 = search_lightcurve(\"HAT-P-11\", mission=\"Kepler\", cadence=\"long\", quarter=10).download()\n",
     "\n",
-    "\n",
+    "# load two quarters into LCviz:\n",
     "lcviz = LCviz()\n",
     "lcviz.load_data(lc_q9, data_label='Q9')\n",
     "lcviz.load_data(lc_q10, data_label='Q10')\n",
@@ -72,12 +78,11 @@
    },
    "outputs": [],
    "source": [
+    "# use the flatten plugin to flatten each quarter:\n",
     "flatten = lcviz.plugins['Flatten']\n",
     "\n",
-    "n_quarters = len(lcviz.app.data_collection)\n",
-    "\n",
-    "for _ in range(n_quarters):\n",
-    "    # flatten once per dataset:\n",
+    "for dataset in flatten.dataset.choices:\n",
+    "    flatten.dataset = dataset\n",
     "    flatten.window_length = 50\n",
     "    flatten.flatten();"
    ]
@@ -99,27 +104,32 @@
    },
    "outputs": [],
    "source": [
-    "import astropy.units as u\n",
-    "from astropy.time import Time\n",
+    "# get the origin of the time axis in LCviz:\n",
+    "time_coordinates = lcviz.app.data_collection[0].coords\n",
+    "reference_time = time_coordinates.reference_time\n",
     "\n",
-    "# origin on the time axis\n",
-    "time_coord = lcviz.app.data_collection[0].coords\n",
-    "reference_time = time_coord.reference_time\n",
-    "\n",
-    "# literature ephemeris for hot Neptune planet HAT-P-11 b\n",
+    "# literature ephemeris for hot Neptune planet HAT-P-11 b:\n",
     "morris2017_epoch = Time(2454605.89146, format='jd')\n",
     "morris2017_period = 4.88780258  # days\n",
     "\n",
-    "# phase the transit light curve\n",
+    "# phase-fold the transit light curve in an ephemeris viewer:\n",
     "eph = lcviz.plugins['Ephemeris']\n",
     "eph.period = morris2017_period\n",
     "eph.t0 = (\n",
     "    (morris2017_epoch - reference_time).to_value(time_coord.unit) % eph.period\n",
     ")\n",
     "\n",
-    "# offset phase axis so mid-transit occurs at phase=0.5\n",
+    "# offset the phase axis so mid-transit occurs at phase=0.5:\n",
     "eph.t0 += 0.5 * eph.period"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74a1adf9-73db-4d7a-8168-c1b842d8680c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Description

This PR adds support for loading multiple data entries into one LCviz instance. Changes required included:
* properly managing the "reference time" of the first loaded data
* consistent linking between temporal axes across time/phase viewers
* using consistent glue `ComponentID`s for time components in the LightCurve translator and in the Ephemeris plugin
* overriding the `viewer.state.reset_limits` method for light curves
* refactoring the `TimeCoordinate` class, which acts as the WCS-like coordinate object for light curves

I also updated the example notebook with Ephemeris and Flatten use cases with two quarters of the HAT-P-11 Kepler light curve.

glue-jupyter's bqplot interface has a `density_map` feature which renders a 2D histogram of datapoints when there are many datapoints in a viewer. In this PR, I turn that feature off for LCviz, though it may be useful to make this toggle easier to access in the future.