### PR TITLE
Moving viewer reference renaming upstream to jdaviz

### DIFF
--- a/lcviz/events.py
+++ b/lcviz/events.py
@@ -1,16 +1,7 @@
 from glue.core.message import Message
 
-__all__ = ['ViewerRenamedMessage', 'EphemerisComponentChangedMessage',
+__all__ = ['EphemerisComponentChangedMessage',
            'EphemerisChangedMessage']
-
-
-class ViewerRenamedMessage(Message):
-    """Message emitted after a viewer is destroyed by the application."""
-    def __init__(self, old_viewer_ref, new_viewer_ref, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.old_viewer_ref = old_viewer_ref
-        self.new_viewer_ref = new_viewer_ref
 
 
 class EphemerisComponentChangedMessage(Message):

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -2,11 +2,10 @@ import numpy as np
 
 from glue.core.subset_group import GroupedSubset
 from jdaviz.configs.imviz.plugins.coords_info import CoordsInfo
+from jdaviz.core.events import ViewerRenamedMessage
 from jdaviz.core.registries import tool_registry
 
 from lcviz.viewers import TimeScatterView, PhaseScatterView
-from lcviz.events import ViewerRenamedMessage
-
 
 __all__ = ['CoordsInfo']
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -318,7 +318,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         # this is triggered when the plugin component detects a change to the component name
         self._ephemerides[new_lbl] = self._ephemerides.pop(old_lbl, {})
         if self._phase_viewer_id(old_lbl) in self.app.get_viewer_ids():
-            self.app.update_viewer_reference_name(
+            self.app._update_viewer_reference_name(
                 self._phase_viewer_id(old_lbl),
                 self._phase_viewer_id(new_lbl),
                 update_id=True

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -318,7 +318,11 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         # this is triggered when the plugin component detects a change to the component name
         self._ephemerides[new_lbl] = self._ephemerides.pop(old_lbl, {})
         if self._phase_viewer_id(old_lbl) in self.app.get_viewer_ids():
-            self.app._rename_viewer(self._phase_viewer_id(old_lbl), self._phase_viewer_id(new_lbl))
+            self.app.update_viewer_reference_name(
+                self._phase_viewer_id(old_lbl),
+                self._phase_viewer_id(new_lbl),
+                update_id=True
+            )
 
         # update metadata entries so that they can be used for filtering applicable entries in
         # data menus

--- a/lcviz/template_mixin.py
+++ b/lcviz/template_mixin.py
@@ -3,22 +3,10 @@ from traitlets import List, Unicode
 from ipyvuetify import VuetifyTemplate
 from glue.core import HubListener
 
-import jdaviz
-from jdaviz.core.template_mixin import ViewerSelect, DatasetSelect, SelectPluginComponent
-from lcviz.events import ViewerRenamedMessage, EphemerisComponentChangedMessage
+from jdaviz.core.template_mixin import DatasetSelect, SelectPluginComponent
+from lcviz.events import EphemerisComponentChangedMessage
 
 __all__ = ['EphemerisSelect', 'EphemerisSelectMixin']
-
-
-# TODO: remove this if/when jdaviz supports renaming viewers natively
-class ViewerSelect(ViewerSelect):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.hub.subscribe(self, ViewerRenamedMessage, handler=self._on_viewers_changed)
-
-
-# monkey-patch upstream version so all plugins use the viewer-renamed logic
-jdaviz.core.template_mixin.ViewerSelect = ViewerSelect
 
 
 class EphemerisSelect(SelectPluginComponent):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "jdaviz>=3.7",
+    "jdaviz>=3.7.1",
     "lightkurve@git+https://github.com/lightkurve/lightkurve",  # until https://github.com/lightkurve/lightkurve/pull/1342 is in a release (anything after 2.4.0)
 ]
 dynamic = [


### PR DESCRIPTION
https://github.com/spacetelescope/jdaviz/pull/2338 implements viewer reference name updates in jdaviz, removing the need for that functionality in LCviz. 

This PR removes the duplicate code, and calls the jdaviz versions. This PR should not be merged until https://github.com/spacetelescope/jdaviz/pull/2338 is on main.

[🐱](https://jira.stsci.edu/browse/JDAT-3680)