### PR TITLE
Fix for ephemeris phase axis

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -189,12 +189,11 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             phases = _times_to_phases(times)
             if component not in self.phase_cids:
                 self.phase_cids[component] = ComponentID(phase_comp_lbl)
-
             # this loop catches phase components generated automatically by
             # when add_results is triggered in other plugins:
             for comp in data.components:
                 if phase_comp_lbl == comp.label:
-                    data.remove_component(comp)
+                    data.remove_component(phase_comp_lbl)
 
             data.add_component(phases, self.phase_cids[component])
             if i != 0:
@@ -251,8 +250,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
                 self.app.set_data_visibility(phase_viewer_id, data.label, visible == 'visible')
 
         pv = self.app.get_viewer(phase_viewer_id)
-        # TODO: there must be a better way to do this...
-        pv.state.x_att = [comp for comp in dc[0].components if comp.label == self.phase_comp_lbl][0]
+        pv.state.x_att = self.phase_cids[self.component_selected]
         return pv
 
     def vue_create_phase_viewer(self, *args):

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -189,6 +189,12 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             phases = _times_to_phases(times)
             if component not in self.phase_cids:
                 self.phase_cids[component] = ComponentID(phase_comp_lbl)
+
+            if self.phase_cids[component] in data.components:
+                data.update_components({self.phase_cids[component]: phases})
+            else:
+                data.add_component(phases, self.phase_cids[component])
+
             # this loop catches phase components generated automatically by
             # when add_results is triggered in other plugins:
             for comp in data.components:

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -215,8 +215,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
 
                 new_links.append(new_link)
 
-        for new_link in new_links:
-            dc.add_link(new_link)
+        dc.add_link(new_links)
 
         # update any plugin markers
         # TODO: eventually might need to loop over multiple matching viewers

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -214,10 +214,9 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
                 )
 
                 new_links.append(new_link)
-                dc.add_link(new_link)
 
-        if len(new_links):
-            dc.set_links(new_links)
+        for new_link in new_links:
+            dc.add_link(new_link)
 
         # update any plugin markers
         # TODO: eventually might need to loop over multiple matching viewers

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -116,7 +116,7 @@
     "eph = lcviz.plugins['Ephemeris']\n",
     "eph.period = morris2017_period\n",
     "eph.t0 = (\n",
-    "    (morris2017_epoch - reference_time).to_value(time_coord.unit) % eph.period\n",
+    "    (morris2017_epoch - reference_time).to_value(time_coordinates.unit) % eph.period\n",
     ")\n",
     "\n",
     "# offset the phase axis so mid-transit occurs at phase=0.5:\n",


### PR DESCRIPTION
Fix for phase axis `ComponentID`s that restores ephemeris support. [🐱](https://jira.stsci.edu/browse/JDAT-3690).