### PR TITLE
update to use skip_if_no_updates_since_last_active

### DIFF
--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -140,7 +140,8 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
 
             mark.visible = this_visible
 
-        if visible:
+        if visible and event.get('name', '') in ('is_active', 'show_live_preview'):
+            # then the marks themselves need to be updated
             self._live_update(event)
 
     @observe('dataset_selected', 'ephemeris_selected',
@@ -151,6 +152,10 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
             self._clear_marks()
             self.bin_enabled = self.n_bins != '' and self.n_bins > 0
             return
+
+        if event.get('name', '') not in ('is_active', 'show_live_preview'):
+            # mark visibility hasn't been handled yet
+            self._toggle_marks()
 
         try:
             lc = self.bin(add_data=False)

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -6,7 +6,8 @@ from jdaviz.core.custom_traitlets import IntHandleEmpty
 from jdaviz.core.events import (ViewerAddedMessage, ViewerRemovedMessage)
 from jdaviz.core.registries import tray_registry
 from jdaviz.core.template_mixin import (PluginTemplateMixin,
-                                        DatasetSelectMixin, AddResultsMixin)
+                                        DatasetSelectMixin, AddResultsMixin,
+                                        skip_if_no_updates_since_last_active)
 from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.events import EphemerisChangedMessage
@@ -125,9 +126,26 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
 
         self.add_results.viewer.filters = [viewer_filter]
 
-    @observe('show_live_preview', 'is_active',
-             'dataset_selected', 'ephemeris_selected',
+    @observe('is_active', 'show_live_preview')
+    def _toggle_marks(self, event={}):
+        visible = self.show_live_preview and self.is_active
+
+        for viewer_id, mark in self.marks.items():
+            if not visible:
+                this_visible = False
+            elif self.ephemeris_selected == 'No ephemeris':
+                this_visible = True
+            else:
+                this_visible = viewer_id.split(':')[-1] == self.ephemeris_selected
+
+            mark.visible = this_visible
+
+        if visible:
+            self._live_update(event)
+
+    @observe('dataset_selected', 'ephemeris_selected',
              'n_bins')
+    @skip_if_no_updates_since_last_active()
     def _live_update(self, event={}):
         if not self.show_live_preview or not self.is_active:
             self._clear_marks()
@@ -155,23 +173,16 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
 
         for viewer_id, mark in self.marks.items():
             if self.ephemeris_selected == 'No ephemeris':
-                visible = True
                 # TODO: fix this to be general and not rely on ugly id
                 do_phase = viewer_id != 'lcviz-0'
             else:
-                # TODO: try to fix flashing as traitlets update
-                visible = viewer_id.split(':')[-1] == self.ephemeris_selected
                 do_phase = False
 
-            if visible:
-                if do_phase:
-                    mark.update_ty(times, lc.flux.value)
-                else:
-                    mark.times = []
-                    mark.update_xy(times, lc.flux.value)
+            if do_phase:
+                mark.update_ty(times, lc.flux.value)
             else:
-                mark.clear()
-            mark.visible = visible
+                mark.times = []
+                mark.update_xy(times, lc.flux.value)
 
     def _on_ephemeris_update(self, msg):
         if not self.show_live_preview or not self.is_active:

--- a/lcviz/plugins/flatten/flatten.py
+++ b/lcviz/plugins/flatten/flatten.py
@@ -170,7 +170,8 @@ class Flatten(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
         for mark in flattened_marks.values():
             mark.visible = visible
 
-        if visible:
+        if visible and event.get('name') in ('is_active', 'show_live_preview'):
+            # then the marks themselves need to be updated
             self._live_update(event)
 
     @observe('dataset_selected',
@@ -185,6 +186,10 @@ class Flatten(PluginTemplateMixin, DatasetSelectMixin, AddResultsMixin):
             self._clear_marks()
             return
         self.flatten_err = ''
+
+        if event.get('name') not in ('is_active', 'show_live_preview'):
+            # mark visibility hasn't been handled yet
+            self._toggle_marks(event)
 
         if self.unnormalize:
             output_flux = output_lc.flux.value

--- a/lcviz/tests/test_plugin_flatten.py
+++ b/lcviz/tests/test_plugin_flatten.py
@@ -54,7 +54,9 @@ def test_plugin_flatten(helper, light_curve_like_kepler_quarter):
         # update polyorder (live-preview should re-appear and have changed from before)
         f.polyorder = before_polyorder + 1
         assert f._obj.flatten_err == ''
-        after_update = _get_marks_from_viewer(tv)[0].y
+        marks = _get_marks_from_viewer(tv)
+        assert len(marks) == 2
+        after_update = marks[0].y
         assert not np.allclose(before_update, after_update)
 
         orig_label = f.dataset.selected


### PR DESCRIPTION
this accompanies https://github.com/spacetelescope/jdaviz/pull/2386 and updates the flatten and binning plugins to make use of this new decorator, which should avoid any flickering for expensive cases.

This will require jdaviz 3.7 ~(once released - marking as draft until then)~.  ~The binning plugin from #28 will also require updates (either as part of that PR or this rebased on top of that once merged)~