### PR TITLE
ephemeris plugin: custom phase-wrapping

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -271,6 +271,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             pv = self.app.get_viewer(phase_viewer_id)
             pv.state.add_callback("x_min", lambda x_min: self._check_phase_viewer_limits(viewer_id=phase_viewer_id))  # noqa
             pv.state.add_callback("x_max", lambda x_max: self._check_phase_viewer_limits(viewer_id=phase_viewer_id))  # noqa
+            pv.state.x_min, pv.state.x_max = (1-self.wrap_at, self.wrap_at)
 
         else:
             pv = self.app.get_viewer(phase_viewer_id)

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -41,7 +41,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
     * :attr:`dpdt`:
       First derivative of the period of the ephemeris.
     * :attr:`wrap_at`:
-      Phase at which to wrap (maximum phase)
+      Phase at which to wrap (phased data will encompass the range 1-wrap_at to wrap_at).
     * :meth:`ephemeris`
     * :meth:`ephemerides`
     * :meth:`update_ephemeris`

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -268,7 +268,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
 
         pv = self.app.get_viewer(phase_viewer_id)
         if create_phase_viewer:
-            pv.state.x_min, pv.state.x_max = (1-self.wrap_at, self.wrap_at)
+            pv.state.x_min, pv.state.x_max = (self.wrap_at-1, self.wrap_at)
         pv.state.x_att = self.phase_cids[self.component_selected]
         return pv
 

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -82,7 +82,7 @@
           v-model.number="wrap_at"
           :step="0.1"
           type="number"
-          :hint="'Phased data will encompass the range (1-'+wrap_at+', '+wrap_at+').'"
+          :hint="'Phased data will encompass the range '+wrap_at_range+'.'"
           persistent-hint
           :rules="[() => wrap_at!=='' || 'This field is required']"
         ></v-text-field>
@@ -160,3 +160,14 @@
 
   </j-tray-plugin>
 </template>
+
+<script>
+module.exports = {
+  computed: {
+    wrap_at_range() {
+      const lower = 1-this.wrap_at
+      return '('+lower.toFixed(2)+', '+this.wrap_at.toFixed(2)+')'
+    },
+  }
+};
+</script>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -80,13 +80,24 @@
           type="number"
           label="Wrapping phase"
           v-model.number="wrap_at"
-          :step="0.2"
+          :step="0.1"
           type="number"
           hint="The phase at which to wrap (maximum phase, may need to reset zoom limits)."
           persistent-hint
           :rules="[() => wrap_at!=='' || 'This field is required']"
         ></v-text-field>
       </v-row>
+
+      <div v-if="!xlimits_contain_all_data">
+        <v-alert type="warning" style="margin-left: -12px; margin-right: -12px">
+          Current viewer x-limits do not encompass all phased data.
+          <v-row justify="center">
+            <v-btn @click="reset_viewer_limits">
+              reset x-limits
+            </v-btn>
+          </v-row>
+        </v-alert>
+      </div>
 
       <j-plugin-section-header>Period Finding/Refining</j-plugin-section-header>
 

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -88,17 +88,6 @@
         ></v-text-field>
       </v-row>
 
-      <div v-if="!xlimits_contain_all_data">
-        <v-alert type="warning" style="margin-left: -12px; margin-right: -12px">
-          Current viewer x-limits do not encompass all phased data.
-          <v-row justify="center">
-            <v-btn @click="reset_viewer_limits">
-              reset x-limits
-            </v-btn>
-          </v-row>
-        </v-alert>
-      </div>
-
       <j-plugin-section-header>Period Finding/Refining</j-plugin-section-header>
 
       <plugin-dataset-select

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -74,6 +74,20 @@
         ></v-text-field>
       </v-row>
 
+      <v-row>
+        <v-text-field
+          ref="wrap_at"
+          type="number"
+          label="Wrapping phase"
+          v-model.number="wrap_at"
+          :step="0.2"
+          type="number"
+          hint="The phase at which to wrap (maximum phase, may need to reset zoom limits)."
+          persistent-hint
+          :rules="[() => wrap_at!=='' || 'This field is required']"
+        ></v-text-field>
+      </v-row>
+
       <j-plugin-section-header>Period Finding/Refining</j-plugin-section-header>
 
       <plugin-dataset-select

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -154,7 +154,7 @@
 module.exports = {
   computed: {
     wrap_at_range() {
-      const lower = 1-this.wrap_at
+      const lower = this.wrap_at - 1
       return '('+lower.toFixed(2)+', '+this.wrap_at.toFixed(2)+')'
     },
   }

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -82,7 +82,7 @@
           v-model.number="wrap_at"
           :step="0.1"
           type="number"
-          hint="The phase at which to wrap (maximum phase, may need to reset zoom limits)."
+          :hint="'Phased data will encompass the range (1-'+wrap_at+', '+wrap_at+').'"
           persistent-hint
           :rules="[() => wrap_at!=='' || 'This field is required']"
         ></v-text-field>

--- a/lcviz/state.py
+++ b/lcviz/state.py
@@ -7,10 +7,12 @@ __all__ = ['ScatterViewerState']
 
 
 class ScatterViewerState(ScatterViewerState):
-    def _get_att_limits(self, ax):
+    def _reset_att_limits(self, ax):
+        # override glue's _reset_x/y_limits to account for all layers,
+        # not just reference data
         att = f'{ax}_att'
         if getattr(self, att) is None:  # pragma: no cover
-            return np.inf, -np.inf
+            return
 
         ax_min, ax_max = np.inf, -np.inf
         for layer in self.layers:
@@ -18,12 +20,6 @@ class ScatterViewerState(ScatterViewerState):
             if len(ax_data) > 0:
                 ax_min = min(ax_min, np.nanmin(ax_data))
                 ax_max = max(ax_max, np.nanmax(ax_data))
-        return ax_min, ax_max
-
-    def _reset_att_limits(self, ax):
-        # override glue's _reset_x/y_limits to account for all layers,
-        # not just reference data
-        ax_min, ax_max = self._get_att_limits(ax)
 
         if not np.all(np.isfinite([ax_min, ax_max])):  # pragma: no cover
             return
@@ -37,11 +33,6 @@ class ScatterViewerState(ScatterViewerState):
 
     def _reset_y_limits(self, *event):
         self._reset_att_limits('y')
-
-    @property
-    def xlimits_contain_all_data(self):
-        data_min, data_max = self._get_att_limits('x')
-        return bool(self.x_min <= data_min and self.x_max >= data_max)
 
     def reset_limits(self, *event):
         x_min, x_max = np.inf, -np.inf

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -74,3 +74,6 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert ephem._obj.method_err == ''
     ephem._obj.vue_adopt_period_at_max_power()
     assert ephem.period != 2
+
+    # test coverage for non-zero dpdt
+    ephem.dpdt = 0.00001

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -1,4 +1,3 @@
-from numpy.testing import assert_allclose
 
 def test_docs_snippets(helper, light_curve_like_kepler_quarter):
     lcviz, lc = helper, light_curve_like_kepler_quarter
@@ -32,16 +31,10 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert ephem.period == 3.14
 
     pv = ephem._obj.phase_viewer
-    assert ephem._obj.xlimits_contain_all_data is True
     # original limits are set to 0->1 (technically 1-phase_wrap -> phase_wrap)
     assert (pv.state.x_min, pv.state.x_max) == (0.0, 1.0)
     ephem.wrap_at = 0.5
-    assert ephem._obj.xlimits_contain_all_data is False
-    ephem._obj.vue_reset_viewer_limits()
-    assert ephem._obj.xlimits_contain_all_data is True
-    # this won't be exactly 0 and 0.5, since it computes the outermost data points,
-    # actual values with the current test data are -0.49999989500376074, 0.4997347643670089
-    assert_allclose((pv.state.x_min, pv.state.x_max), (-0.5, 0.5), atol=0.01)
+    assert (pv.state.x_min, pv.state.x_max) == (-0.5, 0.5)
 
     ephem.add_component('custom component')
     assert not ephem._obj.phase_viewer_exists

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -1,3 +1,5 @@
+from numpy.testing import assert_allclose
+
 def test_docs_snippets(helper, light_curve_like_kepler_quarter):
     lcviz, lc = helper, light_curve_like_kepler_quarter
 
@@ -28,6 +30,18 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert ephem.period == 3.14 * 2
     ephem._obj.vue_period_halve()
     assert ephem.period == 3.14
+
+    pv = ephem._obj.phase_viewer
+    assert ephem._obj.xlimits_contain_all_data is True
+    # original limits are set to 0->1 (technically 1-phase_wrap -> phase_wrap)
+    assert (pv.state.x_min, pv.state.x_max) == (0.0, 1.0)
+    ephem.wrap_at = 0.5
+    assert ephem._obj.xlimits_contain_all_data is False
+    ephem._obj.vue_reset_viewer_limits()
+    assert ephem._obj.xlimits_contain_all_data is True
+    # this won't be exactly 0 and 0.5, since it computes the outermost data points,
+    # actual values with the current test data are -0.49999989500376074, 0.4997347643670089
+    assert_allclose((pv.state.x_min, pv.state.x_max), (-0.5, 0.5), atol=0.01)
 
     ephem.add_component('custom component')
     assert not ephem._obj.phase_viewer_exists

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -113,6 +113,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
             xlabel = f'{str(x_unit.physical_type).title()} ({x_unit})'
 
         self.figure.axes[0].label = xlabel
+        self.figure.axes[0].num_ticks = 5
 
     def _set_plot_y_axes(self, dc, component_labels, light_curve):
         self.state.y_att = dc[0].components[component_labels.index('flux')]
@@ -141,6 +142,8 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
         # Set (X,Y)-axis to scientific notation if necessary:
         self.figure.axes[0].tick_format = 'g'
         self.figure.axes[1].tick_format = 'g'
+
+        self.figure.axes[1].num_ticks = 5
 
     def _expected_subset_layer_default(self, layer_state):
         super()._expected_subset_layer_default(layer_state)
@@ -212,6 +215,7 @@ class PhaseScatterView(TimeScatterView):
         # setting of y_att will be handled by ephemeris plugin
         self.state.x_att = dc[0].components[component_labels.index(f'phase:{self.ephemeris_component}')]  # noqa
         self.figure.axes[0].label = 'phase'
+        self.figure.axes[0].num_ticks = 5
 
     def times_to_phases(self, times):
         ephem = self.jdaviz_helper.plugins.get('Ephemeris', None)

--- a/notebooks/LCvizExample.ipynb
+++ b/notebooks/LCvizExample.ipynb
@@ -119,8 +119,8 @@
     "    (morris2017_epoch - reference_time).to_value(time_coordinates.unit) % eph.period\n",
     ")\n",
     "\n",
-    "# offset the phase axis so mid-transit occurs at phase=0.5:\n",
-    "eph.t0 += 0.5 * eph.period"
+    "# offset the wrapping phase so the transit (at phase 0) displays at center\n",
+    "eph.wrap_at = 0.5"
    ]
   },
   {


### PR DESCRIPTION
This PR implements a "phase_wrap" option in the ephemeris plugin along with automatic phase-limits updates ~a convenient in-plugin identification when the phase-wrapped data falls outside the viewer x-limits~. 

<details>
  <summary>original in-plugin limits warning</summary>
  **NOTE**: hint text for the wrapping UI element has been updated slightly since this recording to say "Phased data will encompass the range (1-wrap_at, wrap_at)"
  
  https://github.com/spacetelescope/lcviz/assets/877591/19a8f6e8-2882-4d5a-b0bb-3de8e642fa2a

</details>


<details open>
  <summary>auto-updating phase-limits</summary>
  
  https://github.com/spacetelescope/lcviz/assets/877591/a012a3e5-f633-4608-8ff7-1e30fe6b15cb

</details>
