### PR TITLE
enable subset freezing

### DIFF
--- a/lcviz/plugins/subset_plugin/subset_plugin.py
+++ b/lcviz/plugins/subset_plugin/subset_plugin.py
@@ -9,3 +9,4 @@ class SubsetPlugin(SubsetPlugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#subset-tools"
+        self.can_freeze = True


### PR DESCRIPTION
This enables support from ~https://github.com/spacetelescope/jdaviz/pull/2421~ https://github.com/spacetelescope/jdaviz/pull/2462 into lcviz's subset plugin.



https://github.com/spacetelescope/lcviz/assets/877591/83ca9d40-5a13-40ff-9675-5629c1db98e3



~This would require that PR to be merged (along with the necessary fixes for get_subsets and the subset plugin), but should not require it to be released in order to move forward with this PR.~

~This can be merged without jdaviz 3.7 released, but will require testing with jdaviz after that PR is merged (lcviz should work with _and_ without, but this feature will only be shown if you have jdaviz _with_ the upstream PR).~