### PR TITLE
DOC: update documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,11 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   apt_packages:
     - graphviz
   tools:
-    python: "3.9"
+    python: "3.11"
   jobs:
     post_checkout:
       # Use `git log` to check if the latest commit contains "skip rtd" or "rtd skip",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_automodapi.automodapi',
     'sphinx.ext.mathjax',
-    'sphinx_design']
+    'sphinx_design',
+    'sphinx_togglebutton']
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,18 +14,16 @@
 
 import datetime
 import sys
-from pathlib import Path
-from pkg_resources import get_distribution
+from lcviz import __version__
 
-if sys.version_info < (3, 11):
-    import tomli as tomllib
-else:
-    import tomllib
+try:
+    from sphinx_astropy.conf.v1 import *  # noqa
+    from sphinx_astropy.conf.v2 import *  # noqa
+except ImportError:
+    print('ERROR: the documentation requires the sphinx-astropy package to be installed')
+    sys.exit(1)
 
 # -- General configuration ------------------------------------------------
-with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
-    conf = tomllib.load(configuration_file)
-setup_cfg = conf["project"]
 
 # Configuration for intersphinx
 intersphinx_mapping = {
@@ -52,7 +50,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx_automodapi.automodapi',
-    'sphinx.ext.mathjax']
+    'sphinx.ext.mathjax',
+    'sphinx_design']
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
@@ -67,8 +66,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project
-project = setup_cfg['name']
-author = setup_cfg['authors'][0]['name']
+project = "lcviz"
+author = "JDADF Developers"
 year = datetime.datetime.now().year
 copyright = f'{year}, {author}'
 
@@ -77,7 +76,8 @@ copyright = f'{year}, {author}'
 # build documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution(project).version
+release = __version__
+dev = "dev" in release
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 
@@ -146,9 +146,36 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ----------------------------------------------
 
+# A NOTE ON HTML THEMES
+# The global astropy configuration uses a custom theme, 'bootstrap-astropy',
+# which is installed along with astropy. A different theme can be used or
+# the options for this theme can be modified by overriding some of the
+# variables set in the global configuration. The variables set in the
+# global configuration are listed below, commented out.
+
+# html_css_files = ["lcviz.css"]
+html_copy_source = False
+
+html_theme_options.update(  # noqa: F405
+    {
+        "github_url": "https://github.com/spacetelescope/lcviz",
+        "use_edit_page_button": True,
+    }
+)
+
+html_context = {
+    "default_mode": "light",
+    "to_be_indexed": ["stable", "latest"],
+    "is_development": dev,
+    "github_user": "spacetelescope",
+    "github_repo": "lcviz",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+# html_theme = 'sphinx_rtd_theme'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ except ImportError:
 
 # Configuration for intersphinx
 intersphinx_mapping = {
+    'jdaviz': ('https://jdaviz.readthedocs.io/en/latest/', None),
     'lightkurve': ('https://docs.lightkurve.org', None)
 #     'python': ('https://docs.python.org/3/',
 #                (None, 'http://data.astropy.org/intersphinx/python3.inv')),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
 LCviz Documentation
 *******************
 
-``lcviz`` is a light curve visualization and analysis tool built on `Jdaviz <https://jdaviz.readthedocs.io>`_
-and `lightkurve <https://docs.lightkurve.org>`_::
+``lcviz`` is a light curve visualization and analysis tool within the Jupyter environment (lab or 
+notebook), built on top of `Jdaviz <https://jdaviz.readthedocs.io>`_ and `lightkurve <https://docs.lightkurve.org>`_::
 
     from lcviz import LCviz
     from lightkurve import search_lightcurve
@@ -15,9 +15,13 @@ and `lightkurve <https://docs.lightkurve.org>`_::
     lcviz.load_data(lc)
     lcviz.show()
 
+It aims to provide tools for the analysis of periodic and semi-periodic variability from
+stationary sources (exoplanets, eclipsing binaries, ellipsoidal variables, pulsating stars,
+rotating stars, etc) in high-cadence photometric data sets, specifically - but not limited to - Kepler, K2, and TESS.
 
-Although ``lcviz`` does implement convenient UI access to ``lightkurve`` functionality, it does not
-aim to be a complete ``lightkurve`` UI, nor is it limited to only features supported by ``lightkurve``.
+Although ``lcviz`` implements convenient UI access to functionality from the ``lightkurve`` python
+package, it does not aim to be a complete ``lightkurve`` UI, nor is it limited to only features
+supported by ``lightkurve``.
 
 Reference/API
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,22 @@
 LCviz Documentation
 *******************
 
-This is the documentation for ``lcviz``,
-a package which contains stuff that do things.
+``lcviz`` is a light curve visualization and analysis tool built on `Jdaviz <https://jdaviz.readthedocs.io>`_
+and `lightkurve <https://docs.lightkurve.org>`_::
+
+    from lcviz import LCviz
+    from lightkurve import search_lightcurve
+
+    lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                           cadence="long", quarter=10).download()
+
+    lcviz = LCviz()
+    lcviz.load_data(lc)
+    lcviz.show()
+
+
+Although ``lcviz`` does implement convenient UI access to ``lightkurve`` functionality, it does not
+aim to be a complete ``lightkurve`` UI, nor is it limited to only features supported by ``lightkurve``.
 
 Reference/API
 =============
@@ -11,5 +25,6 @@ Reference/API
 .. toctree::
    :maxdepth: 2
 
-   reference/api.rst
+   installation.rst
    plugins.rst
+   reference/api.rst

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,128 @@
+
+.. _install:
+
+Install
+=======
+
+.. note::
+
+    ``lcviz`` is undergoing constant development. We encourage users to always update
+    to the latest version. In general, it is good practice to install the development
+    version following the instructions below as full released versions may lag behind.
+
+User Installation
+-----------------
+
+Create Your Local Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some of Jdaviz's dependencies require non-Python packages to work
+(particularly the front-end stack that is part of the Jupyter ecosystem).
+We recommend using `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_
+to easily manage a compatible Python environment for ``jdaviz``; it should work
+with most modern shells, except CSH/TCSH.
+
+You may want to consider installing ``lcaviz`` in a new virtual or conda environment
+to avoid version conflicts with other packages you may have installed, for example:
+
+.. code-block:: bash
+
+    conda create -n lcviz-env python=3.9
+    conda activate lcviz-env
+
+Pip Install
+^^^^^^^^^^^
+
+As noted above, we typically recommend installing the latest development version:
+
+.. code-block:: bash
+
+    pip install git+https://github.com/spacetelescope/lcviz --upgrade
+
+A normal install will also work by installing the latest release version:
+
+.. code-block:: bash
+
+    pip install lcviz --upgrade
+
+Common Issues
+^^^^^^^^^^^^^
+
+If you encounter problems while following these installation instructions,
+please consult :ref:`known installation issues <known_issues_installation>`.
+
+Note that ``lcviz`` requires Python 3.9 or newer. If your ``pip`` corresponds to an older version of
+Python, it will raise an error that it cannot find a valid package.
+
+Users occasionally encounter problems running the pure ``pip`` install above. For those
+using ``conda``, some problems may be resolved by pulling the following from ``conda``
+instead of ``pip``:
+
+.. code-block:: bash
+
+    conda install bottleneck
+    conda install -c conda-forge notebook
+    conda install -c conda-forge jupyterlab
+    conda install -c conda-forge voila
+
+You might also want to enable the ``ipywidgets`` notebook extension, as follows:
+
+.. code-block:: bash
+
+    jupyter nbextension enable --py widgetsnbextension
+
+Developer Installation
+----------------------
+
+If you wish to contribute to ``lcviz``, please fork the project to your
+own GitHub account. The following instructions assume your have forked
+the project and have connected
+`your GitHub to SSH <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_
+and ``username`` is your GitHub username. This is a one-setup setup:
+
+.. code-block:: bash
+
+    git clone git@github.com:username/lcviz.git
+    cd jdaviz
+    git remote add upstream git@github.com:spacetelescope/lcviz.git
+    git fetch upstream main
+    git fetch upstream --tags
+
+To work on a new feature or bug-fix, it is recommended that you build upon
+the latest dev code in a new branch (e.g., ``my-new-feature``).
+You also need the up-to-date tags for proper software versioning:
+
+.. code-block:: bash
+
+    git checkout -b my-new-feature
+    git fetch upstream --tags
+    git fetch upstream main
+    git rebase upstream/main
+
+For the rest of contributing workflow, it is very similar to
+`how to make code contribution to astropy <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_,
+except for the change log.
+If your patch requires a change log, see ``CHANGES.rst`` for examples.
+
+To install ``lcviz`` for development or from source in an editable mode
+(i.e., changes to the locally checked out code would reflect in runtime
+after you restarted the Python kernel):
+
+.. code-block:: bash
+
+    pip install -e .
+
+Optionally, to enable the hot reloading of Vue.js templates, install
+``watchdog``:
+
+.. code-block:: bash
+
+    pip install watchdog
+
+After installing ``watchdog``, to use it, add the following to the top
+of a notebook:
+
+.. code-block:: python
+
+    from lcviz import enable_hot_reloading
+    enable_hot_reloading()

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,12 +22,12 @@ We recommend using `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_
 to easily manage a compatible Python environment for ``jdaviz``; it should work
 with most modern shells, except CSH/TCSH.
 
-You may want to consider installing ``lcaviz`` in a new virtual or conda environment
+You may want to consider installing ``lcviz`` in a new virtual or conda environment
 to avoid version conflicts with other packages you may have installed, for example:
 
 .. code-block:: bash
 
-    conda create -n lcviz-env python=3.9
+    conda create -n lcviz-env python=3.11
     conda activate lcviz-env
 
 Pip Install

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -71,7 +71,7 @@ can be disabled through the plugin settings.
 
 .. seealso::
 
-    This plugin uses the following lightkurve implementations:
+    This plugin uses the following ``lightkurve`` implementations:
 
     * :meth:`lightkurve.LightCurve.flatten`
 
@@ -85,7 +85,7 @@ This plugin exposes the periodogram (in period or frequency space) for an input 
 
 .. seealso::
 
-    This plugin uses the following lightkurve implementations:
+    This plugin uses the following ``lightkurve`` implementations:
 
     * :meth:`lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve`
     * :meth:`lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve`

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -13,6 +13,25 @@ If the data is loaded from multi-extension FITS that contains a primary header,
 you will also see a :guilabel:`Show primary header` toggle, when enabled, would
 display just the primary header metadata.
 
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      metadata = lcviz.plugins['Metadata']
+      print(f"dataset choices: {metadata.dataset.choices}")
+      metadata.dataset = metadata.dataset.choices[0]
+      print(metadata.metadata)
+      
+
 .. seealso::
 
     :ref:`Jdaviz Metadata Viewer <jdaviz:imviz_metadata-viewer>`
@@ -24,6 +43,29 @@ Plot Options
 ============
 
 This plugin gives access to per-viewer and per-layer plotting options.
+
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      po = lcviz.plugins['Plot Options']
+      print(f"viewer choices: {po.viewer.choices}")
+      po.viewer = po.viewer.choices[0]
+      print(f"layer choices: {po.layer.choices}")
+      po.layer = po.layer.choices[0]
+
+      po.marker_size = 4
+      po.marker_color = 'blue'
+
 
 .. seealso::
 
@@ -55,10 +97,32 @@ displayed in the app toolbar into the table.  The markers remain at that fixed p
 the viewer they were created (regardless of changes to the underlying data or linking) and are only
 visible when the plugin is opened.
 
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      markers = lcviz.plugins['Markers']
+      markers.open_in_tray()
+      # interactively mark by mousing over the viewer and pressing "M"
+      table = markers.export_table()
+      print(table)
+      markers.clear_table()
+
+
 .. seealso::
 
     :ref:`Jdaviz Markers <jdaviz:markers-plugin>`
         Jdaviz documentation on the Markers plugin.
+
 
 .. _flatten:
 
@@ -68,6 +132,25 @@ Flatten
 This plugin allows for flattening the light curve by removing trends.  By default, the resulting flattened light curve is
 "unnormalized" by multiplying the flattened light curve by the median of the trend, but this
 can be disabled through the plugin settings.
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      flatten = lcviz.plugins['Flatten']
+      flatten.open_in_tray()
+      flatten.polyorder = 4
+      flattened_lc = flatten.flatten(add_data=True)
+      print(flattened_lc)
+
 
 .. seealso::
 
@@ -82,6 +165,27 @@ Frequency Analysis
 ==================
 
 This plugin exposes the periodogram (in period or frequency space) for an input light curve.
+
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+      
+      freq = lcviz.plugins['Frequency Analysis']
+      freq.open_in_tray()
+      freq.method = 'Lomb-Scargle'
+      freq.xunit = 'period'
+      periodogram = freq.periodogram
+      print(periodogram)
+
 
 .. seealso::
 
@@ -100,12 +204,47 @@ The ephemeris plugin allows for setting, finding, and refining the ephemeris or 
 for phase-folding.
 
 
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      ephem = lcviz.plugins['Ephemeris']
+      ephem.period = 4.88780258
+      ephem.t0 = 2.43
+      ephem.rename_component('default', 'my component name')
+
+
 .. _export-plot:
 
 Export Plot
 ===========
 
 This plugin allows exporting the plot in a given viewer to various image formats.
+
+
+.. admonition:: User API Example
+    :class: dropdown
+
+    .. code-block:: python
+
+      from lcviz import LCviz
+      lc = search_lightcurve("HAT-P-11", mission="Kepler",
+                             cadence="long", quarter=10).download().flatten()
+      lcviz = LCviz()
+      lcviz.load_data(lc)
+      lcviz.show()
+
+      export = lcviz.plugins['Export Plot']
+      export.save_figure('test.png')
+
 
 .. seealso::
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -9,10 +9,6 @@ Metadata Viewer
 
 This plugin allows viewing of any metadata associated with the selected data.
 
-If the data is loaded from multi-extension FITS that contains a primary header,
-you will also see a :guilabel:`Show primary header` toggle, when enabled, would
-display just the primary header metadata.
-
 
 .. admonition:: User API Example
     :class: dropdown

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -15,7 +15,7 @@ display just the primary header metadata.
 
 .. seealso::
 
-    :ref:`Jdaviz Metadata Viewer <jdaviz:imviz-display-settings>`
+    :ref:`Jdaviz Metadata Viewer <jdaviz:imviz_metadata-viewer>`
         Jdaviz documentation on the Metadata Viewer plugin.
 
 .. _plot-options:

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -13,6 +13,11 @@ If the data is loaded from multi-extension FITS that contains a primary header,
 you will also see a :guilabel:`Show primary header` toggle, when enabled, would
 display just the primary header metadata.
 
+.. seealso::
+
+    :ref:`Jdaviz Metadata Viewer <jdaviz:imviz-display-settings>`
+        Jdaviz documentation on the Metadata Viewer plugin.
+
 .. _plot-options:
 
 Plot Options
@@ -20,6 +25,10 @@ Plot Options
 
 This plugin gives access to per-viewer and per-layer plotting options.
 
+.. seealso::
+
+    :ref:`Jdaviz Plot Options <jdaviz:imviz-plot-options>`
+        Jdaviz documentation on the Plot Options plugin.
 
 .. _subset-tools:
 
@@ -28,6 +37,10 @@ Subset Tools
 
 This plugin allows viewing and modifying defined subsets.
 
+.. seealso::
+
+    :ref:`Jdaviz Subset Tools <jdaviz:imviz-subset-plugin>`
+        Jdaviz documentation on the Subset Tools plugin.
 
 .. _markers:
 
@@ -42,6 +55,10 @@ displayed in the app toolbar into the table.  The markers remain at that fixed p
 the viewer they were created (regardless of changes to the underlying data or linking) and are only
 visible when the plugin is opened.
 
+.. seealso::
+
+    :ref:`Jdaviz Markers <jdaviz:markers-plugin>`
+        Jdaviz documentation on the Markers plugin.
 
 .. _flatten:
 
@@ -52,9 +69,11 @@ This plugin allows for flattening the light curve by removing trends.  By defaul
 "unnormalized" by multiplying the flattened light curve by the median of the trend, but this
 can be disabled through the plugin settings.
 
-This plugin uses the following lightkurve implementations:
+.. seealso::
 
-* :meth:`lightkurve.LightCurve.flatten`
+    This plugin uses the following lightkurve implementations:
+
+    * :meth:`lightkurve.LightCurve.flatten`
 
 
 .. _frequency_analysis:
@@ -64,10 +83,12 @@ Frequency Analysis
 
 This plugin exposes the periodogram (in period or frequency space) for an input light curve.
 
-This plugin uses the following lightkurve implementations:
+.. seealso::
 
-* :meth:`lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve`
-* :meth:`lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve`
+    This plugin uses the following lightkurve implementations:
+
+    * :meth:`lightkurve.periodogram.LombScarglePeriodogram.from_lightcurve`
+    * :meth:`lightkurve.periodogram.BoxLeastSquaresPeriodogram.from_lightcurve`
 
 
 .. _ephemeris:
@@ -85,3 +106,8 @@ Export Plot
 ===========
 
 This plugin allows exporting the plot in a given viewer to various image formats.
+
+.. seealso::
+
+    :ref:`Jdaviz Export Plot <jdaviz:imviz-export-plot>`
+        Jdaviz documentation on the Export Plot plugin.

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -6,6 +6,14 @@ API
 
 .. _lcviz-api-configs:
 
+Plugins
+=======
+
+.. toctree::
+  :maxdepth: 2
+
+  api_plugins
+
 LCviz Helper
 ============
 

--- a/docs/reference/api_plugins.rst
+++ b/docs/reference/api_plugins.rst
@@ -1,0 +1,28 @@
+.. _jdaviz-api-plugins:
+
+Plugins API
+===========
+
+.. automodapi:: lcviz.plugins.ephemeris.ephemeris
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.export_plot.export_plot
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.flatten.flatten
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.frequency_analysis.frequency_analysis
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.markers.markers
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.metadata_viewer.metadata_viewer
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.plot_options.plot_options
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.subset_plugin.subset_plugin
+  :no-inheritance-diagram:

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -16,7 +16,7 @@ __all__ = ['FrequencyAnalysis']
 @tray_registry('frequency-analysis', label="Frequency Analysis")
 class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
     """
-    See the :ref:`Frequency Analysis Plugin Documentation <frequency_ananlysis>` for more details.
+    See the :ref:`Frequency Analysis Plugin Documentation <frequency_analysis>` for more details.
 
     Only the following attributes and methods are available through the
     public plugin API.

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -1,3 +1,13 @@
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    ephem = lcviz.plugins['Ephemeris']
+    ephem.period = 4.88780258
+    ephem.t0 = 2.43
+    ephem.rename_component('default', 'my component name')
 
 
 def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):

--- a/lcviz/tests/test_plugin_flatten.py
+++ b/lcviz/tests/test_plugin_flatten.py
@@ -10,6 +10,19 @@ def _get_marks_from_viewer(viewer, cls=(LivePreviewTrend, LivePreviewFlattened),
             if include_not_visible or m.visible]
 
 
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    flatten = lcviz.plugins['Flatten']
+    flatten.open_in_tray()
+    flatten.polyorder = 4
+    flattened_lc = flatten.flatten(add_data=True)
+    print(flattened_lc)
+
+
 def test_plugin_flatten(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)

--- a/lcviz/tests/test_plugin_frequency_analysis.py
+++ b/lcviz/tests/test_plugin_frequency_analysis.py
@@ -3,6 +3,20 @@ from numpy.testing import assert_allclose
 from lightkurve.periodogram import LombScarglePeriodogram, BoxLeastSquaresPeriodogram
 
 
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    freq = lcviz.plugins['Frequency Analysis']
+    freq.open_in_tray()
+    freq.method = 'Lomb-Scargle'
+    freq.xunit = 'period'
+    periodogram = freq.periodogram
+    print(periodogram)
+
+
 def test_plugin_frequency_analysis(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     # tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -19,6 +19,20 @@ def _assert_dict_allclose(dict1, dict2):
             assert v == dict2.get(k)
 
 
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    markers = lcviz.plugins['Markers']
+    markers.open_in_tray()
+    # interactively mark by mousing over the viewer and pressing "M"
+    table = markers.export_table()
+    print(table)
+    markers.clear_table()
+
+
 def test_plugin_markers(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)

--- a/lcviz/tests/test_plugin_metadata.py
+++ b/lcviz/tests/test_plugin_metadata.py
@@ -1,0 +1,10 @@
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    metadata = lcviz.plugins['Metadata']
+    print(f"dataset choices: {metadata.dataset.choices}")
+    metadata.dataset = metadata.dataset.choices[0]
+    print(metadata.metadata)

--- a/lcviz/tests/test_plugin_plot_options.py
+++ b/lcviz/tests/test_plugin_plot_options.py
@@ -1,0 +1,14 @@
+def test_docs_snippets(helper, light_curve_like_kepler_quarter):
+    lcviz, lc = helper, light_curve_like_kepler_quarter
+
+    lcviz.load_data(lc)
+    # lcviz.show()
+
+    po = lcviz.plugins['Plot Options']
+    print(f"viewer choices: {po.viewer.choices}")
+    po.viewer = po.viewer.choices[0]
+    print(f"layer choices: {po.layer.choices}")
+    po.layer = po.layer.choices[0]
+
+    po.marker_size = 4
+    po.marker_color = 'blue'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lcviz"
-description = "A Jdaviz-based lightcurve analysis and visualization tool"
+description = "A Jdaviz-based light curve analysis and visualization tool"
 requires-python = ">=3.8"
 authors = [
     { name = "JDADF Developers", email = "kconroy@stsci.edu" },
@@ -45,8 +45,8 @@ test = [
     "pytest-tornasync",
 ]
 docs = [
-    "sphinx-rtd-theme",
-    "sphinx-astropy",
+    "sphinx-astropy[confv2]>=1.9.1",
+    "sphinx_design"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ test = [
 ]
 docs = [
     "sphinx-astropy[confv2]>=1.9.1",
-    "sphinx_design"
+    "sphinx_design",
+    "sphinx-togglebutton"
 ]
 
 [build-system]


### PR DESCRIPTION
This PR:
* updates the docs theme to use the same as jdaviz
* adds information on the index page briefly explaining lcviz and linking to jdaviz and lightkurve
* copies (relevant) installation information from jdaviz
* exposes API docs for plugins
* links from each plugin to jdaviz/lightkurve, when applicable
* provides user-API snippets for each of the plugins

This does not intend to be a comprehensive/final update to the docs, but just to get in shape for an initial release.  Areas that could still use improvement include:
* add lcviz logo (once created)
* screenshots/recording on splash page
* extended descriptions for each plugin
* development docs (anything that is lcviz-specific, otherwise point to jdaviz docs)

[rendered docs](https://lcviz--46.org.readthedocs.build/en/46/)