### PR TITLE
expose line traitlets through plot options user API

### DIFF
--- a/lcviz/plugins/plot_options/plot_options.py
+++ b/lcviz/plugins/plot_options/plot_options.py
@@ -17,6 +17,7 @@ class PlotOptions(PlotOptions):
                         'marker_size_mode', 'marker_size', 'marker_size_scale',
                         'marker_size_col', 'marker_size_vmin', 'marker_size_vmax',
                         'marker_color_mode', 'marker_color', 'marker_color_col',
-                        'marker_colormap', 'marker_colormap_vmin', 'marker_colormap_vmax']
+                        'marker_colormap', 'marker_colormap_vmin', 'marker_colormap_vmax',
+                        'line_visible', 'line_width']
 
         return api


### PR DESCRIPTION
This PR accompanies https://github.com/spacetelescope/jdaviz/pull/2449 and exposes the now-supported line traitlets through the plot options user API.

~**Waiting for:** jdaviz 3.8~