### PR TITLE
Binning: handle n_bins being empty or <= 0

### DIFF
--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -132,7 +132,12 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
             self._clear_marks()
             return
 
-        lc = self.bin(add_data=False)
+        try:
+            lc = self.bin(add_data=False)
+        except Exception:
+            self._clear_marks()
+            return
+
         # TODO: remove the need for this (inconsistent quantity vs value setting in lc object)
         lc_time = getattr(lc.time, 'value', lc.time)
 
@@ -173,6 +178,10 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
         self._live_update()
 
     def bin(self, add_data=True):
+
+        if self.n_bins == '' or self.n_bins <= 0:
+            raise ValueError("n_bins must be a positive integer")
+
         input_lc = self.input_lc
 
         lc = input_lc.bin(time_bin_size=(input_lc.time[-1]-input_lc.time[0]).value/self.n_bins)

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -43,6 +43,7 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
     show_live_preview = Bool(True).tag(sync=True)
 
     n_bins = IntHandleEmpty(100).tag(sync=True)
+    bin_enabled = Bool(True).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -130,13 +131,17 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
     def _live_update(self, event={}):
         if not self.show_live_preview or not self.is_active:
             self._clear_marks()
+            self.bin_enabled = self.n_bins != '' and self.n_bins > 0
             return
 
         try:
             lc = self.bin(add_data=False)
         except Exception:
             self._clear_marks()
+            self.bin_enabled = False
             return
+        else:
+            self.bin_enabled = True
 
         # TODO: remove the need for this (inconsistent quantity vs value setting in lc object)
         lc_time = getattr(lc.time, 'value', lc.time)

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -68,6 +68,7 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Bin"
       action_tooltip="Bin data"
+      :action_disabled="!bin_enabled"
       @click:action="apply"
     ></plugin-add-results>
 

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lcviz.marks import LivePreviewBinning
 
 
@@ -47,3 +49,19 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
         ephem.period = 1.222
 
         b.bin(add_data=True)
+
+        # setting to invalid n_bins will raise error
+        b.n_bins = 0
+        assert b._obj.bin_enabled is False
+        with pytest.raises(ValueError):
+            b.bin(add_data=False)
+
+        # the enabled state of the button should work with or without live previews enabled
+        b.show_live_preview = False
+        assert len(_get_marks_from_viewer(tv)) == 0
+        assert len(_get_marks_from_viewer(pv)) == 0
+        assert b._obj.bin_enabled is False
+        b.n_bins = 1
+        assert b._obj.bin_enabled is True
+        b.n_bins = ''
+        assert b._obj.bin_enabled is False


### PR DESCRIPTION
This PR handles the case where the user empties the input for number of bins or sets it to an invalid value.  The live-preview now clears without a traceback and the "bin" button is disabled.  The input validation shows red text describing the reason the input is invalid (unchanged by this PR).