### PR TITLE
Use upstream updates to plugin plots

### DIFF
--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -69,7 +69,7 @@ class Binning(PluginTemplateMixin, DatasetSelectMixin, EphemerisSelectMixin, Add
 
     @property
     def user_api(self):
-        expose = ['dataset', 'ephemeris', 'input_lc',
+        expose = ['show_live_preview', 'dataset', 'ephemeris', 'input_lc',
                   'n_bins', 'add_results', 'bin']
         return PluginUserApi(self, expose=expose)
 

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -178,7 +178,9 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
 
         per = self.periodogram
         if per is not None:
-            self.plot._update_data('periodogram', x=getattr(per, self.xunit_selected), y=per.power.value)
+            self.plot._update_data('periodogram',
+                                   x=getattr(per, self.xunit_selected),
+                                   y=per.power.value)
             self.plot.update_style('periodogram', line_visible=True, markers_visible=False)
             self._update_periodogram_labels(per)
         else:

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -144,7 +144,7 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
             old_xmin, old_xmax = self.plot.viewer.state.x_min, self.plot.viewer.state.x_max
             new_xmin = old_xmax ** -1 if old_xmax > 0 else np.nanmin(x)
             new_xmax = old_xmin ** -1 if old_xmin > 0 else np.nanmax(x)
-            self.plot.set_lims(x_min=new_xmin, x_max=new_xmax)
+            self.plot.set_limits(x_min=new_xmin, x_max=new_xmax)
         else:
             self.plot.update_style('periodogram', visible=False)
 

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -71,6 +71,10 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
                                            manual_options=['frequency', 'period'])
 
         self.plot.figure.axes[1].label = 'power'
+        self.plot.figure.fig_margin = {'top': 60, 'bottom': 60, 'left': 65, 'right': 15}
+        self.plot.viewer.axis_y.num_ticks = 5
+        self.plot.viewer.axis_y.tick_format = '0.2e'
+        self.plot.viewer.axis_y.label_offset = '55px'
         self._update_xunit()
 
     # TODO: remove if/once inherited from jdaviz

--- a/lcviz/tests/test_plugin_frequency_analysis.py
+++ b/lcviz/tests/test_plugin_frequency_analysis.py
@@ -37,19 +37,19 @@ def test_plugin_frequency_analysis(helper, light_curve_like_kepler_quarter):
 
     freq.xunit = 'period'
     assert freq._obj.plot.figure.axes[0].label == 'period (d)'
-    line_x = freq._obj.plot.marks['line'].x
+    line_x = freq._obj.plot.layers['periodogram'].layer['x']
     assert_allclose((line_x.min(), line_x.max()), (0.3508333334885538, 31.309906458683404))
 
     freq.auto_range = False
     assert_allclose((freq.minimum, freq.maximum), (1, 10))
     while freq._obj.spinner:
         pass
-    line_x = freq._obj.plot.marks['line'].x
+    line_x = freq._obj.plot.layers['periodogram'].layer['x']
     assert_allclose((line_x.min(), line_x.max()), (1, 10.00141))
 
     freq.xunit = 'frequency'
     assert_allclose((freq.minimum, freq.maximum), (0.1, 1))
     while freq._obj.spinner:
         pass
-    line_x = freq._obj.plot.marks['line'].x
+    line_x = freq._obj.plot.layers['periodogram'].layer['x']
     assert_allclose((line_x.min(), line_x.max()), (0.0999859, 1))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "jdaviz>=3.7.1",
+    "jdaviz>=3.8",
     "lightkurve@git+https://github.com/lightkurve/lightkurve",  # until https://github.com/lightkurve/lightkurve/pull/1342 is in a release (anything after 2.4.0)
 ]
 dynamic = [


### PR DESCRIPTION
This updates the plot in frequency analysis to account for changes upstream in https://github.com/spacetelescope/jdaviz/pull/2498 (which adds tool and pan/zoom support), and in doing so requires jdaviz 3.8.

Note that this also means that without this PR, the former implementation _may_ be broken once jdaviz 3.8 is released.

~**Waiting for:** jdaviz 3.8~