### PR TITLE
flatten/binning: handle slow live-updates for large data

### DIFF
--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -57,6 +57,24 @@
       </v-text-field>
     </v-row>
 
+    <v-alert v-if="previews_temp_disable && show_live_preview" type='warning' style="margin-left: -12px; margin-right: -12px">
+      Live-updating is temporarily disabled (last update took {{last_live_time}}s)
+      <v-row justify='center'>
+        <j-tooltip tooltipcontent='hide live preview (can be re-enabled from the settings section in the plugin).' span_style="width: 100%">
+          <v-btn style='width: 100%' @click="show_live_preview = false">
+            disable previews
+          </v-btn>
+        </j-tooltip>
+      </v-row>
+      <v-row justify='center'>
+        <j-tooltip tooltipcontent='manually update live-previews based on current plugin inputs.' span_style="width: 100%">
+          <v-btn style='width: 100%' @click="previews_temp_disable = false">
+            update preview
+          </v-btn>
+        </j-tooltip>
+      </v-row>
+    </v-alert>
+
     <plugin-add-results
       :label.sync="results_label"
       :label_default="results_label_default"

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -87,6 +87,7 @@
       action_label="Bin"
       action_tooltip="Bin data"
       :action_disabled="!bin_enabled"
+      :action_spinner="spinner"
       @click:action="apply"
     ></plugin-add-results>
 

--- a/lcviz/plugins/flatten/flatten.vue
+++ b/lcviz/plugins/flatten/flatten.vue
@@ -138,6 +138,24 @@
       <v-alert type="warning">Live preview is unnormalized, but flattening will normalize.</v-alert>
     </v-row>
 
+    <v-alert v-if="previews_temp_disable && (show_live_preview || show_trend_preview)" type='warning' style="margin-left: -12px; margin-right: -12px">
+      Live-updating is temporarily disabled (last update took {{last_live_time}}s)
+      <v-row justify='center'>
+        <j-tooltip tooltipcontent='hide live trend and flattened previews (can be re-enabled from the settings section in the plugin).' span_style="width: 100%">
+          <v-btn style='width: 100%' @click="() => {show_live_preview = false; show_trend_preview = false}">
+            disable previews
+          </v-btn>
+        </j-tooltip>
+      </v-row>
+      <v-row justify='center'>
+        <j-tooltip tooltipcontent='manually update live-previews based on current plugin inputs.' span_style="width: 100%">
+          <v-btn style='width: 100%' @click="previews_temp_disable = false">
+            update preview
+          </v-btn>
+        </j-tooltip>
+      </v-row>
+    </v-alert>
+
     <plugin-add-results
       :label.sync="results_label"
       :label_default="results_label_default"
@@ -149,7 +167,7 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Flatten"
       action_tooltip="Flatten data"
-      :action_disabled="flatten_err.length > 0"
+      :action_disabled="flatten_err.length > 0 || spinner"
       @click:action="apply"
     ></plugin-add-results>
 

--- a/lcviz/plugins/flatten/flatten.vue
+++ b/lcviz/plugins/flatten/flatten.vue
@@ -167,7 +167,8 @@
       :add_to_viewer_selected.sync="add_to_viewer_selected"
       action_label="Flatten"
       action_tooltip="Flatten data"
-      :action_disabled="flatten_err.length > 0 || spinner"
+      :action_disabled="flatten_err.length > 0"
+      :action_spinner="spinner"
       @click:action="apply"
     ></plugin-add-results>
 


### PR DESCRIPTION
This PR introduces a check on the time that the live-updates take, and if exceeding a certain threshold, temporarily disables the live-preview updates and shows an alert prompting to either manually update the live-preview or disable the live-preview marks.

This also makes use of a [change upstream in jdaviz](https://github.com/spacetelescope/jdaviz/pull/2560) to show a spinner in the "apply" buttons when the plugin is computing which temporarily disables clicking the button.  For cases where binning/flattening is slow to run, this gives immediate feedback that the button was clicked and doesn't need to be clicked again.  This doesn't need to be blocked by pinning a new release of jdaviz, ~but should make sure that PR gets merged first~.

The code here can be simplified slightly by using the `@with_spinner()` decorator from https://github.com/spacetelescope/jdaviz/pull/2560, but that can be a follow-up once that is in a jdaviz release.


Note: this video was before some style changes in https://github.com/spacetelescope/jdaviz/pull/2560 - the check marks are now gone and will show a spinner, if running on jdaviz main.  If not running on main, the "bin" button will not react, but everything else will still work.

https://github.com/spacetelescope/lcviz/assets/877591/ac98e261-d4d6-43f7-990a-b8db96d1537d

