### PR TITLE
Swap component order to add data with correct axes on first go

### DIFF
--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -107,6 +107,17 @@ class LightCurveHandler:
 
         data.meta.update({'uncertainty_type': 'std'})
 
+        # if the anticipated x and y axes are the first two components in the
+        # Data object, the viewer will load those components correctly before
+        # you hit the call to `viewer.set_plot_axes`:
+        reordered_components = {comp.label: comp for comp in data.components}
+        dt_comp = reordered_components.pop('dt')
+        flux_comp = reordered_components.pop('flux')
+        data.reorder_components(
+            [dt_comp, flux_comp] +
+            list(reordered_components.values())
+        )
+
         return data
 
     def to_object(self, data_or_subset):


### PR DESCRIPTION
I wanted to make a demo with three Kepler quarters at short cadence, which contains 297,584 measurements. It was so slow that I was terribly sad. Here's a screen grab (before):

https://github.com/spacetelescope/lcviz/assets/3497584/530afdc9-070c-48e6-8d18-fc3d0bd40483

I executed `load_data` at 0:16, and the cell completes at 1:00 (44 seconds).

I found a silly and simple way to make it more performant. By default, the viewer will plot the first component in the `Data` as the x axis, and second component in y. On `main`, those are `dt` and `time`, which is not the correct y axis, of course. Late in the `viewer.add_data` process we call `set_plot_axes`, which switches to the correct axes. By starting off on the wrong foot, we have to wait for the data to be fully added before they are corrected.

In this PR, I simply reorder the components, and I was surprised by the improvement:

https://github.com/spacetelescope/lcviz/assets/3497584/112cd311-07b6-489f-bd92-d854ccde822a

After this PR, `load_data` started at 0:09 ends by 0:14 (5 seconds).