### PR TITLE
Fix traitlet float64 warning

### DIFF
--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -169,7 +169,7 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
         per = self.periodogram
         if per is not None:
             line = self.plot.marks['line']
-            line.x, line.y = getattr(per, self.xunit_selected), per.power
+            line.x, line.y = getattr(per, self.xunit_selected).value, per.power.value
             self._update_periodogram_labels(per)
         else:
             self.plot.clear_all_marks()


### PR DESCRIPTION
In Frequency Analysis, we plot the periodogram like so:

https://github.com/spacetelescope/lcviz/blob/b4bf32abef08242406b4c3e888f1249e0737ac95/lcviz/plugins/frequency_analysis/frequency_analysis.py#L172

Since the periodogram returns `Quantity`s for period and power, the traitlet can't successfully validate the array input, raising:
```
UserWarning: Given trait value dtype "float64" does not match required type "float64". A coerced copy has been created.
```

This PR extracts the `Quantity`s' values as ndarrays to avoid the warning.