### PR TITLE
Expose marker color column in API

### DIFF
--- a/lcviz/plugins/plot_options/plot_options.py
+++ b/lcviz/plugins/plot_options/plot_options.py
@@ -16,7 +16,7 @@ class PlotOptions(PlotOptions):
         api._expose += ['marker_visible', 'marker_fill', 'marker_opacity',
                         'marker_size_mode', 'marker_size', 'marker_size_scale',
                         'marker_size_col', 'marker_size_vmin', 'marker_size_vmax',
-                        'marker_color_mode', 'marker_color',
+                        'marker_color_mode', 'marker_color', 'marker_color_col',
                         'marker_colormap', 'marker_colormap_vmin', 'marker_colormap_vmax']
 
         return api


### PR DESCRIPTION
This _useful_ feature is supported in the UI but inaccessible from the public API.