### PR TITLE
Add folding period to ephemeris viewers axis label

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -468,6 +468,9 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
                              1./1000000)
         self.t0_step = round_to_1(self.period/1000)
 
+        # update x axis label
+        self.phase_viewer.set_plot_axes()
+
         if not self._default_initialized:
             # other plugins that use EphemerisSelect don't see the first entry yet
             self._default_initialized = True

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -219,8 +219,13 @@ class PhaseScatterView(TimeScatterView):
     def _set_plot_x_axes(self, dc, component_labels, light_curve):
         # setting of y_att will be handled by ephemeris plugin
         self.state.x_att = dc[0].components[component_labels.index(f'phase:{self.ephemeris_component}')]  # noqa
-        self.figure.axes[0].label = 'phase'
         self.figure.axes[0].num_ticks = 5
+
+        ephem = self.jdaviz_helper.plugins.get('Ephemeris', None)
+        if ephem:
+            self.figure.axes[0].label = f'phase (P = {ephem.period:.2g} d)'
+        else:
+            self.figure.axes[0].label = 'phase'
 
     def times_to_phases(self, times):
         ephem = self.jdaviz_helper.plugins.get('Ephemeris', None)


### PR DESCRIPTION
It's easy to forget what period you have set in the Ephemeris plugin, and it's a bit annoying to need to open the plugin if it isn't already visible. This confusion is multiplied when you have multiple ephemerides (with distinct periods).

This PR adds the period to the x-axis label in phase viewers. Here's an example for RR Lyra:

<img width="1296" alt="Screen Shot 2023-11-13 at 20 53 35" src="https://github.com/spacetelescope/lcviz/assets/3497584/81ec3197-4440-4b8d-bb8b-2055f809099f">

The x axis is probably the best place to put the period label for now. I tried using bqplot's `title` attr, but it only sits at the top-center. See the right-most phase viewer here: 

<img width="1296" alt="Screen Shot 2023-11-13 at 21 06 48" src="https://github.com/spacetelescope/lcviz/assets/3497584/7d59a527-fcb4-4f06-abdc-d39c5d8d5f58">

Often the data will sit beneath that label, so I prefer the x label.