### PR TITLE
demo notebook for triple eclipsing system

### DIFF
--- a/notebooks/LCvizDemoMultEphem.ipynb
+++ b/notebooks/LCvizDemoMultEphem.ipynb
@@ -109,7 +109,7 @@
    "source": [
     "## Phase-Folding\n",
     "\n",
-    "Similarly, we'll use the \"Ephemeris\" plugin to create two ephemerides: one for the inner and one for the outer orbit.  As these ephemerides are created, new phase viewers will dynamically be created to show the same light curve in the phase-space as defined by that ephemeris.  Similarly to the flattening plugin, this call all also be done interactively through the \"Ephemeris\" plugin, with the phase-folding updated in real-time."
+    "We can use the \"Ephemeris\" plugin to visualize two periodic features in this light curve: one period for the inner binary, and another period for the outer star's orbit.  As each ephemeris is added, a new phase viewer will be created to show the light curve folded on that period.  As with the Flatten plugin above, the UI allows for live-updating interactive workflows through the \"Ephemeris\" plugin."
    ]
   },
   {


### PR DESCRIPTION
This is a demo notebook illustrating using the flatten and ephemeris plugins for KIC 2835289 - a triple eclipsing system with an ellipsoidal variable as the inner-binary.  It demonstrates API commands to manage multiple ephemerides and could be extended with subset workflows or coloring by phase (avoiding too much overlap with #63).

This requires:
* #64 
* https://github.com/spacetelescope/jdaviz/pull/2563 

~**Waiting for**: jdaviz 3.8 (for `close_in_tray` and API access to set viewer limits)~