### PR TITLE
set min lightkurve version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "astropy>=5.2",
     "jdaviz>=3.8",
-    "lightkurve@git+https://github.com/lightkurve/lightkurve",  # until https://github.com/lightkurve/lightkurve/pull/1342 is in a release (anything after 2.4.0)
+    "lightkurve>=2.4.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
This PR sets the min lightkurve version now that the upstream PR is actually released, instead of relying on referencing the latest on main directly.