### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -60,7 +60,7 @@ jobs:
           - name: Windows - Python 3.9
             os: windows-latest
             python: 3.9
-            toxenv: py38-test
+            toxenv: py39-test
             allow_failure: false
 
           # This also runs on cron but we want to make sure new changes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     if: github.repository == 'spacetelescope/lcviz'
 
     steps:
@@ -48,6 +50,3 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       if: github.event_name != 'pull_request'
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  # NOTE: PR trigger is to ensure changes do not break packaging.
+  pull_request:
+  release:
+    types: [released]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    if: github.repository == 'spacetelescope/lcviz'
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install python-build and twine
+      run: python -m pip install build "twine>=3.3"
+
+    - name: Build package
+      run: python -m build --sdist --wheel .
+
+    - name: List result
+      run: ls -l dist
+
+    - name: Check dist
+      run: python -m twine check --strict dist/*
+
+    - name: Test package
+      run: |
+        cd ..
+        python -m venv testenv
+        testenv/bin/pip install pytest pytest-astropy pytest-tornasync lcviz/dist/*.whl
+        testenv/bin/python -c "import lcviz; lcviz.test(remote_data=True)"
+
+    # NOTE: Do not run this part for PR testing.
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: github.event_name != 'pull_request'
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,5 @@
-Changes included in this version
---------------------------------
+0.1.0 - unreleased
+------------------
 
-Edit this template to detail updates to the codebase
+* Initial release of lcviz with support to import time-series light curves via lightkurve and
+  process them through binning, flattening, frequency analysis, and ephemeris plugins.

--- a/lcviz/__init__.py
+++ b/lcviz/__init__.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import os
+from astropy.tests.runner import TestRunner
+
 try:
     from .version import version as __version__
 except ImportError:
@@ -15,3 +18,6 @@ from .parsers import *  # noqa
 from .tools import *  # noqa
 from .viewers import *  # noqa
 from .helper import *  # noqa
+
+# Create the test function for self test
+test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "jdaviz>=3.8",
+    "jdaviz==3.8.*",
     "lightkurve>=2.4.1",
 ]
 dynamic = [


### PR DESCRIPTION
This PR enables `lcviz.test` and adapts the release workflow used in jdaviz.

- [x] ~need to setup the secret token in the repo before first release!~ (switched to hopefully working with trusted publisher without the need for a token)
- [ ] do we want changelog enforcement going forward?  (That can always be added later though)