### PR TITLE
remove support for python 3.8

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,9 +57,9 @@ jobs:
             toxenv: py39-test
             allow_failure: false
 
-          - name: Windows - Python 3.8
+          - name: Windows - Python 3.9
             os: windows-latest
-            python: 3.8
+            python: 3.9
             toxenv: py38-test
             allow_failure: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lcviz"
 description = "A Jdaviz-based light curve analysis and visualization tool"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "JDADF Developers", email = "kconroy@stsci.edu" },
 ]


### PR DESCRIPTION
CI tests are stalling and jdaviz does not support python 3.8 anyways