### PR TITLE
Fixing density map toggle for short cadence data for HAT-P-7 notebook

### DIFF
--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -181,7 +181,12 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
             self.plot._update_data('periodogram',
                                    x=getattr(per, self.xunit_selected),
                                    y=per.power.value)
-            self.plot.update_style('periodogram', line_visible=True, markers_visible=False)
+            self.plot.update_style(
+                'periodogram',
+                density_map=False,
+                line_visible=True,
+                markers_visible=False
+            )
             self._update_periodogram_labels(per)
         else:
             self.plot.update_style('periodogram', visible=False)


### PR DESCRIPTION
https://github.com/kecnry/lcviz-demos/pull/2 shows an example notebook for short cadence observations. It is currently failing with jdaviz main because the light curve has 300k measurements, which triggers glue's `density_map` scatter viewer mode. We have guardrails to prevent this from happening in the time scatter viewer, but the periodogram plot in the plugin-specific frequency analysis viewer did not have the `density_map` set to False. For reasons I don't fully understand, the density map causes a failure later on in glue-jupyter. 

It's possible that case could use an upstream fix in glue-jupyter. But for now, we wouldn't want a density map in the periodogram viewer anyway, so it's quite easy to make this change locally to fix our use case.