### PR TITLE
fix target for export plot shortcut button

### DIFF
--- a/lcviz/tools.py
+++ b/lcviz/tools.py
@@ -1,5 +1,5 @@
-from jdaviz.core.tools import SidebarShortcutPlotOptions
-
+from jdaviz.core.tools import SidebarShortcutPlotOptions, SidebarShortcutExportPlot
 
 # point to the lcviz-version of plot options instead of jdaviz's
 SidebarShortcutPlotOptions.plugin_name = 'lcviz-plot-options'
+SidebarShortcutExportPlot.plugin_name = 'lcviz-export-plot'


### PR DESCRIPTION
We override the export plot plugin, so need to point to the lcviz version in the toolbar shortcut.