### PR TITLE
ephemeris component validation

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -100,7 +100,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
                                                        manual_options=['default'],
                                                        on_add=self._on_component_add,
                                                        on_rename_after_selection=self._on_component_rename,  # noqa
-                                                       on_remove_after_selection=self._on_component_remove)  # noqa
+                                                       on_remove_after_selection=self._on_component_remove,  # noqa
+                                                       validate_choice=self._validate_component)
 
         # force the original entry in ephemerides with defaults
         self._change_component()
@@ -310,6 +311,13 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
     def _check_if_phase_viewer_exists(self, *args):
         viewer_base_refs = [id.split('[')[0] for id in self.app.get_viewer_ids()]
         self.phase_viewer_exists = self.phase_viewer_id in viewer_base_refs
+
+    def _validate_component(self, lbl):
+        if '[' in lbl or ']' in lbl:
+            return 'cannot contain square brackets'
+        if ':' in lbl:
+            return 'cannot contain colon'
+        return ''
 
     def _on_component_add(self, lbl):
         self.hub.broadcast(EphemerisComponentChangedMessage(old_lbl=None, new_lbl=lbl,

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -1,4 +1,8 @@
 import pytest
+from packaging.version import Version
+
+import jdaviz
+JDAVIZ_LT_3_9_0 = Version(jdaviz.__version__) < Version('3.9.0')
 
 
 def test_docs_snippets(helper, light_curve_like_kepler_quarter):
@@ -45,12 +49,13 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert len(ephem.ephemerides) == 2
     assert 'custom component' in ephem.ephemerides
 
-    with pytest.raises(ValueError):
-        # brackets interfere with cloned viewer label logic
-        ephem.rename_component('custom component', 'custom component[blah]')
-    with pytest.raises(ValueError):
-        # colons interfere with viewer ephemeris logic
-        ephem.rename_component('custom component', 'custom component:blah')
+    if not JDAVIZ_LT_3_9_0:
+        with pytest.raises(ValueError):
+            # brackets interfere with cloned viewer label logic
+            ephem.rename_component('custom component', 'custom component[blah]')
+        with pytest.raises(ValueError):
+            # colons interfere with viewer ephemeris logic
+            ephem.rename_component('custom component', 'custom component:blah')
 
     ephem.rename_component('custom component', 'renamed custom component')
     assert len(ephem.ephemerides) == 2

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -1,3 +1,5 @@
+import pytest
+
 
 def test_docs_snippets(helper, light_curve_like_kepler_quarter):
     lcviz, lc = helper, light_curve_like_kepler_quarter
@@ -42,6 +44,13 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     assert len(helper.app.get_viewer_ids()) == 3
     assert len(ephem.ephemerides) == 2
     assert 'custom component' in ephem.ephemerides
+
+    with pytest.raises(ValueError):
+        # brackets interfere with cloned viewer label logic
+        ephem.rename_component('custom component', 'custom component[blah]')
+    with pytest.raises(ValueError):
+        # colons interfere with viewer ephemeris logic
+        ephem.rename_component('custom component', 'custom component:blah')
 
     ephem.rename_component('custom component', 'renamed custom component')
     assert len(ephem.ephemerides) == 2


### PR DESCRIPTION
This PR implements validation in ephemeris component naming to avoid breaking assumptions when parsing viewer names.

This won't do anything without the [upstream PR](https://github.com/spacetelescope/jdaviz/pull/2642), so the new tests have a condition to change behavior based on the version of jdaviz (which can then be removed in #68).

Eventually we might be able to remove this if/when we refactor the viewers to hold the information about their ephemeris, etc, within metadata instead of the label itself.  That would then allow us to set these labels by default, but allow the users to rename them without losing the ability to manage them from the plugins. [:cat:](https://jira.stsci.edu/browse/JDAT-4111)