### PR TITLE
TPF viewer

### DIFF
--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -53,14 +53,14 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     app.add_data(data, new_data_label)
 
     if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
-        # ensure a TPF viewer exists
+        # ensure an image/cube/TPF viewer exists
         # TODO: move this to an event listener on add_data so that we can also remove when empty?
         from jdaviz.core.events import NewViewerMessage
         from lcviz.viewers import CubeView
-        viewer_reference_name = 'tpf'
+        viewer_reference_name = 'image'
         if viewer_reference_name not in app._viewer_store.keys():
             app._on_new_viewer(NewViewerMessage(CubeView, data=None, sender=app),
-                               vid='tpf', name='tpf')
+                               vid='image', name='image')
         if show_in_viewer:
             app.add_data_to_viewer(viewer_reference_name, new_data_label)
 

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -5,14 +5,14 @@ from jdaviz.configs.imviz.plugins.coords_info import CoordsInfo
 from jdaviz.core.events import ViewerRenamedMessage
 from jdaviz.core.registries import tool_registry
 
-from lcviz.viewers import TimeScatterView, PhaseScatterView
+from lcviz.viewers import TimeScatterView, PhaseScatterView, CubeView
 
 __all__ = ['CoordsInfo']
 
 
 @tool_registry('lcviz-coords-info')
 class CoordsInfo(CoordsInfo):
-    _supported_viewer_classes = (TimeScatterView, PhaseScatterView)
+    _supported_viewer_classes = (TimeScatterView, PhaseScatterView, CubeView)
     _viewer_classes_with_marker = (TimeScatterView, PhaseScatterView)
 
     def __init__(self, *args, **kwargs):
@@ -25,12 +25,7 @@ class CoordsInfo(CoordsInfo):
     def _viewer_renamed(self, msg):
         self._marks[msg.new_viewer_ref] = self._marks.pop(msg.old_viewer_ref)
 
-    def update_display(self, viewer, x, y):
-        self._dict = {}
-
-        if not len(viewer.state.layers):
-            return
-
+    def _lc_viewer_update(self, viewer, x, y):
         is_phase = isinstance(viewer, PhaseScatterView)
         # TODO: update with display_unit when supported in lcviz
         x_unit = '' if is_phase else str(viewer.time_unit)
@@ -138,3 +133,14 @@ class CoordsInfo(CoordsInfo):
 
         self.marks[viewer._reference_id].update_xy([closest_x], [closest_y])  # noqa
         self.marks[viewer._reference_id].visible = True
+
+    def update_display(self, viewer, x, y):
+        self._dict = {}
+
+        if not len(viewer.state.layers):
+            return
+
+        if isinstance(viewer, (TimeScatterView, PhaseScatterView)):
+            self._lc_viewer_update(viewer, x, y)
+        elif isinstance(viewer, CubeView):
+            self._image_viewer_update(viewer, x, y)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -18,7 +18,7 @@ from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 
 from lcviz.state import ScatterViewerState
 
-from lightkurve import LightCurve
+from lightkurve import LightCurve, KeplerTargetPixelFile
 
 __all__ = ['TimeScatterView', 'PhaseScatterView', 'CubeView']
 
@@ -276,10 +276,8 @@ class CubeView(CloneViewerMixin, CubevizImageView):
                     ['bqplot:rectangle'],
                     ['lcviz:viewer_clone', 'jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
-#    default_class = TargetPixelFile  # TODO: does this need to use the factory?
-#    _state_cls = ScatterViewerState
-
-#    _native_mark_classnames = ('Image', 'ImageGL', 'Scatter', 'ScatterGL')
+    # TODO: can we vary this default_class based on Kepler vs TESS, etc?
+    default_class = KeplerTargetPixelFile
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -308,7 +308,7 @@ class CubeView(CloneViewerMixin, CubevizImageView):
         super()._on_layers_update(layers=layers)
         flux_comp = self.state.reference_data.id['flux']
         for layer in self.state.layers:
-            if layer.attribute != flux_comp:
+            if hasattr(layer, 'attribute') and layer.attribute != flux_comp:
                 layer.attribute = flux_comp
 
     def data(self, cls=None):

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -274,7 +274,7 @@ class CubeView(CloneViewerMixin, CubevizImageView):
                     ['jdaviz:boxzoom'],
                     ['jdaviz:panzoom'],
                     ['bqplot:rectangle'],
-                    ['lcviz:viewer_clone', 'jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
+                    ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
     # TODO: can we vary this default_class based on Kepler vs TESS, etc?
     default_class = KeplerTargetPixelFile
@@ -300,12 +300,16 @@ class CubeView(CloneViewerMixin, CubevizImageView):
         # Make sure that the x_att/y_att is correct on data load
         # called via a callback set upstream in CubevizImageView when reference_data is changed
         ref_data = self.state.reference_data
-        self.state.x_att = ref_data.id['Pixel Axis 2 [x]']
-        self.state.y_att = ref_data.id['Pixel Axis 1 [y]']
+        if ref_data is not None:
+            self.state.x_att = ref_data.id['Pixel Axis 2 [x]']
+            self.state.y_att = ref_data.id['Pixel Axis 1 [y]']
 
     def _on_layers_update(self, layers=None):
         super()._on_layers_update(layers=layers)
-        flux_comp = self.state.reference_data.id['flux']
+        ref_data = self.state.reference_data
+        if ref_data is None:
+            return
+        flux_comp = ref_data.id['flux']
         for layer in self.state.layers:
             if hasattr(layer, 'attribute') and layer.attribute != flux_comp:
                 layer.attribute = flux_comp

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -18,7 +18,7 @@ from jdaviz.configs.specviz.plugins.viewers import SpecvizProfileView
 
 from lcviz.state import ScatterViewerState
 
-from lightkurve import LightCurve, KeplerTargetPixelFile
+from lightkurve import LightCurve
 
 __all__ = ['TimeScatterView', 'PhaseScatterView', 'CubeView']
 
@@ -277,7 +277,8 @@ class CubeView(CloneViewerMixin, CubevizImageView):
                     ['jdaviz:sidebar_plot', 'jdaviz:sidebar_export']
                 ]
     # TODO: can we vary this default_class based on Kepler vs TESS, etc?
-    default_class = KeplerTargetPixelFile
+    # see https://github.com/spacetelescope/lcviz/pull/81#discussion_r1469721009
+    default_class = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -298,6 +298,7 @@ class CubeView(CloneViewerMixin, CubevizImageView):
 
     def _initial_x_axis(self, *args):
         # Make sure that the x_att/y_att is correct on data load
+        # called via a callback set upstream in CubevizImageView when reference_data is changed
         ref_data = self.state.reference_data
         self.state.x_att = ref_data.id['Pixel Axis 2 [x]']
         self.state.y_att = ref_data.id['Pixel Axis 1 [y]']


### PR DESCRIPTION
This PR implements a dynamically-created TPF viewer.

- [x] dynamic viewer to visualize cube (with appropriate data filtering in menu)
- [x] mouseover support for cube viewer(s)
- [x] fix viewer without any data (fails when attempting to set attributes)
    * follow-up: re-enable clone viewer tool for TPF viewers [:cat:](https://jira.stsci.edu/browse/JDAT-4156)
- [x] filter/exclude TPF entries from lc viewer data menus (~might need logic or refactoring upstream~ - see https://github.com/spacetelescope/jdaviz/pull/2678)

Note that in order to get correct mouseover and stretch histogram, https://github.com/spacetelescope/jdaviz/pull/2678 is required (which is targeted for jdaviz 3.9).  Even with that, the default stretch percentile often drives the whole range, requiring using a custom stretch [:cat:](https://jira.stsci.edu/browse/JDAT-4155).  


<img width="1488" alt="image" src="https://github.com/spacetelescope/lcviz/assets/877591/570b3c8e-94da-4bbd-b647-d64613dd6f1c">

Example case:

```
from lightkurve import search_lightcurve, search_targetpixelfile
from lcviz import LCviz

lc = search_lightcurve("HAT-P-11", mission="Kepler", cadence="long", quarter=10).download() #.flatten()
tpf = search_targetpixelfile("HAT-P-11", mission="Kepler", cadence="long", quarter=10).download()


lcviz = LCviz()
lcviz.load_data(lc)
lcviz.load_data(tpf)
lcviz.show()
```


Manually setting stretch and colormap:

```
po = lcviz.plugins['Plot Options']
po.viewer = 'image'
po.axes_visible = True
po.image_colormap = 'Viridis'
po.stretch_vmin = 0
po.stretch_vmax = 20000
po.open_in_tray()
```

Until the slice plugin is integrated, slicing can be done manually:

```
lcviz.viewers['image']._obj.state.slices = (slice_number, 0, 0)
```

Next up:
* slice plugin with indicator in all time viewers (try to generalize and inherit from upstream)
    * read-only slice indicators in phase viewers (???)
    * slice plugin to be able to revive viewer if deleted (in a reusable way that can later be also used in the extraction plugin or any other plugin that acts on cubes)
* extraction plugin with live-preview and pipeline defaults