### PR TITLE
fix creating phase-viewer when TPF is loaded

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -289,6 +289,9 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
 
             time_viewer_item = self.app._get_viewer_item(self.app._jdaviz_helper._default_time_viewer_reference_name)  # noqa
             for data in dc:
+                if data.ndim > 1:
+                    # skip image/cube entries
+                    continue
                 data_id = self.app._data_id_from_label(data.label)
                 visible = time_viewer_item['selected_data_items'].get(data_id, 'hidden')
                 self.app.set_data_visibility(phase_viewer_id, data.label, visible == 'visible')


### PR DESCRIPTION
Previously, if a TPF was loaded before the phase-viewer was created, then the TPF data was loaded into the phase-viewer, resulting in a traceback.  Now when creating a phase-viewer, only 1D data are loaded into the viewer (with visibilities still defaulted based on the visibilities in the time viewer).