### PR TITLE
ephemeris plugin: phase viewer user API and float support for times_to_phases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 * Flatten plugin no longer creates new data entries, but instead appends a new column to the input
   light curve and selects as the flux column (origin). [#77]
 
+* Ephemeris plugin now supports passing floats to ``times_to_phases``. [#87]
+
+* Ephemeris plugin's ``create_phase_viewer`` now returns the public user API instance of the viewer
+  instead of the underlying object. [#87]
+
 0.1.0 (12-14-2023)
 ------------------
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -183,7 +183,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             wrap_at = ephem.get('wrap_at', _default_wrap_at)
 
         def _callable(times):
-            if not len(times):
+            if hasattr(times, '__len__') and not len(times):
                 return []
             if dpdt != 0:
                 return np.mod(1./dpdt * np.log(1 + dpdt/period*(times-t0)) + (1-wrap_at), 1.0) - (1-wrap_at)  # noqa

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -300,7 +300,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         if create_phase_viewer:
             pv.state.x_min, pv.state.x_max = (self.wrap_at-1, self.wrap_at)
         pv.state.x_att = self.app._jdaviz_helper._component_ids[self.phase_comp_lbl]
-        return pv
+        return pv.user_api
 
     def vue_create_phase_viewer(self, *args):
         self.create_phase_viewer()

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -27,7 +27,7 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     b._obj.plugin_opened = True
     ephem = helper.plugins['Ephemeris']
     ephem.period = 1.2345
-    pv = ephem.create_phase_viewer()
+    pv = ephem.create_phase_viewer()._obj
 
     with b.as_active():
         assert b.ephemeris == 'No ephemeris'

--- a/lcviz/tests/test_plugin_flatten.py
+++ b/lcviz/tests/test_plugin_flatten.py
@@ -28,7 +28,7 @@ def test_plugin_flatten(helper, light_curve_like_kepler_quarter):
     tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
 
     ephem = helper.plugins['Ephemeris']
-    pv = ephem.create_phase_viewer()
+    pv = ephem.create_phase_viewer()._obj
     f = helper.plugins['Flatten']
 
     # no marks until plugin opened/active

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -67,7 +67,7 @@ def test_plugin_markers(helper, light_curve_like_kepler_quarter):
     assert len(_get_markers_from_viewer(tv).x) == 1
 
     ephem = helper.plugins['Ephemeris']
-    pv = ephem.create_phase_viewer()
+    pv = ephem.create_phase_viewer()._obj
 
     # test event in flux-vs-phase viewer
     label_mouseover._viewer_mouse_event(pv,


### PR DESCRIPTION
Instead of exposing the entire viewer object when calling `ephem.create_phase_viewer()`, this instead exposes the user API introduced in https://github.com/spacetelescope/jdaviz/pull/2563 (already included in the existing jdaviz 3.8 pin).

This also adds support for passing floats through `ephem.times_to_phases`.