### PR TITLE
Fix cloned phase-viewers when deleting/renaming an ephemeris component

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.2.0 - unreleased
 ------------------
 
-* Clone viewer tool. [#74]
+* Clone viewer tool. [#74, #91]
 
 * Flux column plugin to choose which column is treated as the flux column for each dataset. [#77]
 

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -84,3 +84,22 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
 
     # test that non-zero dpdt does not crash
     ephem.dpdt = 0.005
+
+
+def test_cloned_phase_viewer(helper, light_curve_like_kepler_quarter):
+    helper.load_data(light_curve_like_kepler_quarter)
+    ephem = helper.plugins['Ephemeris']
+
+    pv1 = ephem.create_phase_viewer()
+    pv2 = pv1._obj.clone_viewer()
+    assert len(helper.viewers) == 3
+    assert pv1._obj.reference_id == 'flux-vs-phase:default'
+    assert pv2._obj.reference_id == 'flux-vs-phase:default[1]'
+
+    # renaming ephemeris should update both labels
+    ephem.rename_component('default', 'renamed')
+    assert pv1._obj.reference_id == 'flux-vs-phase:renamed'
+    assert pv2._obj.reference_id == 'flux-vs-phase:renamed[1]'
+
+    ephem.remove_component('renamed')
+    assert len(helper.viewers) == 1  # just flux-vs-phase

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -36,7 +36,7 @@ def test_plugin_ephemeris(helper, light_curve_like_kepler_quarter):
     ephem._obj.vue_period_halve()
     assert ephem.period == 3.14
 
-    pv = ephem._obj.phase_viewer
+    pv = ephem._obj.default_phase_viewer
     # original limits are set to 0->1 (technically 1-phase_wrap -> phase_wrap)
     assert (pv.state.x_min, pv.state.x_max) == (0.0, 1.0)
     ephem.wrap_at = 0.5


### PR DESCRIPTION
Previously cloned phase-viewers (introduced in #74, not yet in a release) were not updated (renamed or removed) when an ephemeris component was renamed.  This PR updates the ephemeris plugin to be aware that there may be multiple phase-viewers corresponding to the ephemeris, and treats the "first" as the default when assigning defaults based on axes limits, etc.

(ignore the crashing time plot - too many notebooks running at once)


https://github.com/spacetelescope/lcviz/assets/877591/70eb135a-3562-49c9-9884-ed38e9e30991


devdeps failure is likely because of jdaviz, but we are still pinned to jdaviz 3.8 (and those tests are passing).  See #92 and #68.
