### PR TITLE
Viewer creator in app toolbar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
-0.2.0 - unreleased
+0.3.0 - unreleased
+------------------
+
+* Ability to create additional viewers. [#94]
+
+0.2.0 (02-26-2024)
 ------------------
 
 * Clone viewer tool. [#74, #91]

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -7,10 +7,9 @@ from lightkurve import LightCurve
 from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
 from jdaviz.core.helpers import ConfigHelper
+from lcviz.viewers import TimeScatterView
 
 __all__ = ['LCviz']
-
-_default_time_viewer_reference_name = 'flux-vs-time'
 
 custom_components = {'plugin-ephemeris-select': 'components/plugin_ephemeris_select.vue'}
 
@@ -22,11 +21,7 @@ for name, path in custom_components.items():
 
 
 def _get_range_subset_bounds(self, subset_state, *args, **kwargs):
-    # Instead of overriding the jdaviz version of this method on jdaviz.Application,
-    # we could put in jdaviz by (1) checking if helper has a
-    # _default_time_viewer_reference_name, (2) using the LCviz version if so, and (3)
-    # using the jdaviz version otherwise.
-    viewer = self.get_viewer(self._jdaviz_helper._default_time_viewer_reference_name)
+    viewer = self._jdaviz_helper.default_time_viewer._obj
     light_curve = viewer.data()[0]
     reference_time = light_curve.meta['reference_time']
     if viewer:
@@ -86,7 +81,6 @@ class LCviz(ConfigHelper):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._default_time_viewer_reference_name = _default_time_viewer_reference_name
 
         # override jdaviz behavior to support temporal subsets
         self.app._get_range_subset_bounds = (
@@ -151,6 +145,14 @@ class LCviz(ConfigHelper):
             Data is returned as type cls with subsets applied.
         """
         return super()._get_data(data_label=data_label, mask_subset=subset, cls=cls)
+
+    @property
+    def default_time_viewer(self):
+        tvs = [viewer for vid, viewer in self.app._viewer_store.items()
+               if isinstance(viewer, TimeScatterView)]
+        if not len(tvs):
+            raise ValueError("no time viewers exist")
+        return tvs[0].user_api
 
     @property
     def _tray_tools(self):

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -71,7 +71,7 @@ class LCviz(ConfigHelper):
                                  'tab_headers': True},
                      'dense_toolbar': False,
                      'context': {'notebook': {'max_height': '600px'}}},
-        'toolbar': ['g-data-tools', 'g-subset-tools', 'g-viewer-creator', 'lcviz-coords-info'],
+        'toolbar': ['g-data-tools', 'g-subset-tools', 'lcviz-viewer-creator', 'lcviz-coords-info'],
         'tray': ['lcviz-metadata-viewer', 'flux-column',
                  'lcviz-plot-options', 'lcviz-subset-plugin',
                  'lcviz-markers', 'flatten', 'frequency-analysis', 'ephemeris',

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -152,6 +152,31 @@ class LCviz(ConfigHelper):
         """
         return super()._get_data(data_label=data_label, mask_subset=subset, cls=cls)
 
+    @property
+    def _tray_tools(self):
+        """
+        Access API objects for plugins in the app toolbar.
+
+        Returns
+        -------
+        plugins : dict
+            dict of plugin objects
+        """
+        # TODO: provide user-friendly labels, user API, and move upstream to be public
+        # for now this is just useful for dev-debugging access to toolbar entries
+        from ipywidgets.widgets import widget_serialization
+        return {item['name']: widget_serialization['from_json'](item['widget'], None)
+                for item in self.app.state.tool_items}
+
+    def _get_clone_viewer_reference(self, reference):
+        base_name = reference.split("[")[0]
+        name = base_name
+        ind = 0
+        while name in self.viewers.keys():
+            ind += 1
+            name = f"{base_name}[{ind}]"
+        return name
+
     def _phase_comp_lbl(self, component):
         return f'phase:{component}'
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -71,7 +71,7 @@ class LCviz(ConfigHelper):
                                  'tab_headers': True},
                      'dense_toolbar': False,
                      'context': {'notebook': {'max_height': '600px'}}},
-        'toolbar': ['g-data-tools', 'g-subset-tools', 'lcviz-coords-info'],
+        'toolbar': ['g-data-tools', 'g-subset-tools', 'g-viewer-creator', 'lcviz-coords-info'],
         'tray': ['lcviz-metadata-viewer', 'flux-column',
                  'lcviz-plot-options', 'lcviz-subset-plugin',
                  'lcviz-markers', 'flatten', 'frequency-analysis', 'ephemeris',

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -3,6 +3,8 @@ from glue.config import data_translator
 from jdaviz.core.registries import data_parser_registry
 import lightkurve
 
+from lcviz.viewers import PhaseScatterView
+
 __all__ = ["light_curve_parser"]
 
 
@@ -45,10 +47,10 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         app.add_data_to_viewer(time_viewer_reference_name, new_data_label)
 
         # add to any known phase viewers
-        ephem_plugin = app._jdaviz_helper.plugins.get('Ephemeris', None)
-        if ephem_plugin is not None:
-            for viewer_id in ephem_plugin._obj.phase_viewer_ids:
-                app.add_data_to_viewer(viewer_id, new_data_label)
+        for viewer_id, viewer in app._viewer_store.items():
+            if not isinstance(viewer, PhaseScatterView):
+                continue
+            app.add_data_to_viewer(viewer_id, new_data_label)
 
 
 def _data_with_reftime(app, light_curve):

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -3,15 +3,13 @@ from glue.config import data_translator
 from jdaviz.core.registries import data_parser_registry
 import lightkurve
 
-from lcviz.viewers import PhaseScatterView
+from lcviz.viewers import PhaseScatterView, TimeScatterView
 
 __all__ = ["light_curve_parser"]
 
 
 @data_parser_registry("light_curve_parser")
 def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwargs):
-    time_viewer_reference_name = app._jdaviz_helper._default_time_viewer_reference_name
-
     # load local FITS file from disk by its path:
     if isinstance(file_obj, str) and os.path.exists(file_obj):
         if data_label is None:
@@ -44,13 +42,12 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     app.add_data(data, new_data_label)
 
     if show_in_viewer:
-        app.add_data_to_viewer(time_viewer_reference_name, new_data_label)
-
-        # add to any known phase viewers
+        # add to any known time/phase viewers
         for viewer_id, viewer in app._viewer_store.items():
-            if not isinstance(viewer, PhaseScatterView):
-                continue
-            app.add_data_to_viewer(viewer_id, new_data_label)
+            if isinstance(viewer, TimeScatterView):
+                app.add_data_to_viewer(viewer_id, new_data_label)
+            elif isinstance(viewer, PhaseScatterView):
+                app.add_data_to_viewer(viewer_id, new_data_label)
 
 
 def _data_with_reftime(app, light_curve):

--- a/lcviz/plugins/__init__.py
+++ b/lcviz/plugins/__init__.py
@@ -1,5 +1,7 @@
-from .binning.binning import *  # noqa
+from .viewer_creator.viewer_creator import *  # noqa
 from .coords_info.coords_info import *  # noqa
+
+from .binning.binning import *  # noqa
 from .ephemeris.ephemeris import *  # noqa
 from .export_plot.export_plot import *  # noqa
 from .flatten.flatten import *  # noqa

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -15,9 +15,9 @@ from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.components import FluxColumnSelectMixin
 from lcviz.events import EphemerisChangedMessage
-from lcviz.helper import _default_time_viewer_reference_name
 from lcviz.marks import LivePreviewBinning
 from lcviz.parsers import _data_with_reftime
+from lcviz.viewers import TimeScatterView
 from lcviz.components import EphemerisSelectMixin
 
 
@@ -129,11 +129,11 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
         def viewer_filter(viewer):
             if self.ephemeris_selected in self.ephemeris._manual_options:
-                return viewer.reference == _default_time_viewer_reference_name
+                return isinstance(viewer, TimeScatterView)
             if 'flux-vs-phase:' not in viewer.reference:
                 # ephemeris selected, but no active phase viewers
                 return False
-            return viewer.reference.split('flux-vs-phase:')[1] == self.ephemeris_selected
+            return viewer._ephemeris_component == self.ephemeris_selected
 
         self.add_results.viewer.filters = [viewer_filter]
 

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -68,7 +68,8 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
             return data.meta.get('Plugin', None) != self.__class__.__name__
         self.dataset.add_filter(not_from_binning_plugin)
 
-        self.hub.subscribe(self, ViewerAddedMessage, handler=self._set_results_viewer)
+        # TODO: viewer added also needs to repopulate marks
+        self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_add_viewer)
         self.hub.subscribe(self, ViewerRemovedMessage, handler=self._set_results_viewer)
         self.hub.subscribe(self, EphemerisChangedMessage, handler=self._on_ephemeris_update)
 
@@ -95,15 +96,15 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
     @property
     def marks(self):
         marks = {}
-        for id, viewer in self.app._viewer_store.items():
+        for viewer in self.app._viewer_store.values():
             for mark in viewer.figure.marks:
                 if isinstance(mark, LivePreviewBinning):
-                    marks[id] = mark
+                    marks[viewer.reference] = mark
                     break
             else:
                 mark = LivePreviewBinning(viewer, visible=self.is_active)
                 viewer.figure.marks = viewer.figure.marks + [mark]
-                marks[id] = mark
+                marks[viewer.reference] = mark
         return marks
 
     def _clear_marks(self):
@@ -137,17 +138,23 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
         self.add_results.viewer.filters = [viewer_filter]
 
+    def _on_add_viewer(self, msg):
+        self._set_results_viewer()
+        self._live_update()
+
     @observe('is_active', 'show_live_preview')
     def _toggle_marks(self, event={}):
         visible = self.show_live_preview and self.is_active
 
-        for viewer_id, mark in self.marks.items():
+        for viewer_ref, mark in self.marks.items():
             if not visible:
                 this_visible = False
             elif self.ephemeris_selected == 'No ephemeris':
                 this_visible = True
             else:
-                this_visible = viewer_id.split(':')[-1] == self.ephemeris_selected
+                viewer = self.app.get_viewer(viewer_ref)
+                viewer_ephem = getattr(viewer, '_ephemeris_component', None)
+                this_visible = viewer_ephem == self.ephemeris_selected
 
             mark.visible = this_visible
 
@@ -260,10 +267,11 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
             if self.ephemeris_selected != 'No ephemeris':
                 # prevent phase axis from becoming a time axis:
-                viewer_id = self.ephemeris_plugin._obj.phase_viewer_id
-                pv = self.app.get_viewer(viewer_id)
+                ephemeris_plugin = self.app._jdaviz_helper.plugins['Ephemeris']
                 phase_comp_lbl = self.app._jdaviz_helper._phase_comp_lbl(self.ephemeris_selected)
-                pv.state.x_att = self.app._jdaviz_helper._component_ids[phase_comp_lbl]
+                phase_comp = self.app._jdaviz_helper._component_ids[phase_comp_lbl]
+                for pv in ephemeris_plugin._obj._get_phase_viewers(self.ephemeris_selected):
+                    pv.state.x_att = phase_comp
                 # by resetting x_att, the preview marks may have dissappeared
                 self._live_update()
 

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -17,7 +17,7 @@ from lcviz.components import FluxColumnSelectMixin
 from lcviz.events import EphemerisChangedMessage
 from lcviz.marks import LivePreviewBinning
 from lcviz.parsers import _data_with_reftime
-from lcviz.viewers import TimeScatterView
+from lcviz.viewers import TimeScatterView, PhaseScatterView
 from lcviz.components import EphemerisSelectMixin
 
 
@@ -130,7 +130,7 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
         def viewer_filter(viewer):
             if self.ephemeris_selected in self.ephemeris._manual_options:
                 return isinstance(viewer, TimeScatterView)
-            if 'flux-vs-phase:' not in viewer.reference:
+            if not isinstance(viewer, PhaseScatterView):
                 # ephemeris selected, but no active phase viewers
                 return False
             return viewer._ephemeris_component == self.ephemeris_selected

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -304,7 +304,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         self._check_if_phase_viewer_exists()
 
         # set default data visibility
-        time_viewer_item = self.app._get_viewer_item(self.app._jdaviz_helper._default_time_viewer_reference_name)  # noqa
+        time_viewer_item = self.app._get_viewer_item(self.app._jdaviz_helper.default_time_viewer._obj.reference)  # noqa
         for data in dc:
             data_id = self.app._data_id_from_label(data.label)
             visible = time_viewer_item['selected_data_items'].get(data_id, 'hidden')

--- a/lcviz/plugins/flatten/flatten.py
+++ b/lcviz/plugins/flatten/flatten.py
@@ -102,26 +102,26 @@ class Flatten(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin):
         trend_marks = {}
         flattened_marks = {}
 
-        for id, viewer in self.app._viewer_store.items():
+        for viewer in self.app._viewer_store.values():
             needs_trend = isinstance(viewer, TimeScatterView) and not isinstance(viewer, PhaseScatterView)  # noqa
             needs_flattened = isinstance(viewer, (TimeScatterView, PhaseScatterView))
             for mark in viewer.figure.marks:
                 if isinstance(mark, LivePreviewTrend):
-                    trend_marks[id] = mark
+                    trend_marks[viewer.reference] = mark
                     needs_trend = False
                 elif isinstance(mark, LivePreviewFlattened):
-                    flattened_marks[id] = mark
+                    flattened_marks[viewer.reference] = mark
                     needs_flattened = False
                 if not needs_trend and not needs_flattened:
                     break
             if needs_trend:
                 mark = LivePreviewTrend(viewer, visible=self.is_active)
                 viewer.figure.marks = viewer.figure.marks + [mark]
-                trend_marks[id] = mark
+                trend_marks[viewer.reference] = mark
             if needs_flattened:
                 mark = LivePreviewFlattened(viewer, visible=self.is_active)
                 viewer.figure.marks = viewer.figure.marks + [mark]
-                flattened_marks[id] = mark
+                flattened_marks[viewer.reference] = mark
 
         return trend_marks, flattened_marks
 

--- a/lcviz/plugins/viewer_creator/__init__.py
+++ b/lcviz/plugins/viewer_creator/__init__.py
@@ -1,0 +1,1 @@
+from .viewer_creator import *  # noqa

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -1,6 +1,8 @@
 from jdaviz.configs.default.plugins import ViewerCreator
-from jdaviz.core.registries import tool_registry, viewer_registry
+from jdaviz.core.events import NewViewerMessage
+from jdaviz.core.registries import tool_registry
 from lcviz.events import EphemerisComponentChangedMessage
+from lcviz.viewers import TimeScatterView
 
 __all__ = ['ViewerCreator']
 
@@ -35,8 +37,11 @@ class ViewerCreator(ViewerCreator):
             ephem_plg = self.app._jdaviz_helper.plugins['Ephemeris']
             ephem_plg.create_phase_viewer(ephem_comp)
             return
-        if name == 'flux-vs-time':
+        if name in ('flux-vs-time', 'lcviz-time-viewer'):
             # allow passing label and map to the name for upstream support
-            name = 'lcviz-time-viewer'
+            viewer_id = self.app._jdaviz_helper._get_clone_viewer_reference('flux-vs-time')
+            self.app._on_new_viewer(NewViewerMessage(TimeScatterView, data=None, sender=self.app),
+                                    vid=viewer_id, name=viewer_id)
+            return
 
         super().vue_create_viewer(name)

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -1,6 +1,7 @@
 from jdaviz.configs.default.plugins import ViewerCreator
 from jdaviz.core.registries import tool_registry, viewer_registry
 from lcviz.events import EphemerisComponentChangedMessage
+from lcviz.viewers import ephem_component_from_phase_viewer_name
 
 __all__ = ['ViewerCreator']
 
@@ -38,13 +39,15 @@ class ViewerCreator(ViewerCreator):
 
         if label in self.app._jdaviz_helper.viewers:
             # clone whenever possible
+            # TODO: update this to not rely directly on the label for phase-viewers, but rather
+            # checking for the same ephemeris
             self.app._jdaviz_helper.viewers[label]._obj.clone_viewer()
             return
 
         if name == 'lcviz-phase-viewer':
-            # TODO: parse label to get ephemeris
-            # TODO: copy of plugin and set the correct ephemeris (or allow create_phase_viewer to take ephem component)
-            self.app._jdaviz_helper.plugins['Ephemeris'].create_phase_viewer()
+            ephem_comp = ephem_component_from_phase_viewer_name(label)
+            ephem_plg = self.app._jdaviz_helper.plugins['Ephemeris']
+            ephem_plg.create_phase_viewer(ephem_comp)
             return
 
         super().vue_create_viewer(name)

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -5,7 +5,7 @@ from lcviz.events import EphemerisComponentChangedMessage
 __all__ = ['ViewerCreator']
 
 
-@tool_registry('g-viewer-creator', overwrite=True)  # overwrite requires upstream changes, we can do without if we just lose the tooltip
+@tool_registry('lcviz-viewer-creator')
 class ViewerCreator(ViewerCreator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -1,0 +1,50 @@
+from jdaviz.configs.default.plugins import ViewerCreator
+from jdaviz.core.registries import tool_registry, viewer_registry
+from lcviz.events import EphemerisComponentChangedMessage
+
+__all__ = ['ViewerCreator']
+
+
+@tool_registry('g-viewer-creator', overwrite=True)  # overwrite requires upstream changes, we can do without if we just lose the tooltip
+class ViewerCreator(ViewerCreator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.hub.subscribe(self, EphemerisComponentChangedMessage,
+                           handler=self._rebuild_available_viewers)
+        self._rebuild_available_viewers()
+
+    def _rebuild_available_viewers(self, *args):
+        # filter to lcviz-specific viewers only
+        # list of dictionaries with name (registry name)
+        # and label (what appears in dropdown and the default label of the viewer)
+
+        if self.app._jdaviz_helper is not None:
+            phase_viewers = [{'name': 'lcviz-phase-viewer', 'label': f'flux-vs-phase:{e}'}
+                              for e in self.app._jdaviz_helper.plugins['Ephemeris'].component.choices]  # noqa
+        else:
+            phase_viewers = []
+
+        self.viewer_types = [v for v in self.viewer_types if v['name'].startswith('lcviz')
+                             and v['label'] != 'flux-vs-phase'] + phase_viewers
+
+    def vue_create_viewer(self, name):
+        for viewer_item in self.viewer_types:
+            if viewer_item['name'] == name:
+                label = viewer_item['label']
+                break
+        else:
+            label = viewer_registry.members[name]['label']
+
+        if label in self.app._jdaviz_helper.viewers:
+            # clone whenever possible
+            self.app._jdaviz_helper.viewers[label]._obj.clone_viewer()
+            return
+
+        if name == 'lcviz-phase-viewer':
+            # TODO: parse label to get ephemeris
+            # TODO: copy of plugin and set the correct ephemeris (or allow create_phase_viewer to take ephem component)
+            self.app._jdaviz_helper.plugins['Ephemeris'].create_phase_viewer()
+            return
+
+        super().vue_create_viewer(name)

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -25,7 +25,8 @@ class ViewerCreator(ViewerCreator):
             phase_viewers = [{'name': f'lcviz-phase-viewer:{e}', 'label': f'flux-vs-phase:{e}'}
                               for e in self.app._jdaviz_helper.plugins['Ephemeris'].component.choices]  # noqa
         else:
-            phase_viewers = []
+            phase_viewers = [{'name': 'lcviz-phase-viewer:default',
+                              'label': 'flux-vs-phase:default'}]
 
         self.viewer_types = [v for v in self.viewer_types if v['name'].startswith('lcviz')
                              and not v['label'].startswith('flux-vs-phase')] + phase_viewers

--- a/lcviz/plugins/viewer_creator/viewer_creator.py
+++ b/lcviz/plugins/viewer_creator/viewer_creator.py
@@ -1,7 +1,6 @@
 from jdaviz.configs.default.plugins import ViewerCreator
 from jdaviz.core.registries import tool_registry, viewer_registry
 from lcviz.events import EphemerisComponentChangedMessage
-from lcviz.viewers import ephem_component_from_phase_viewer_name
 
 __all__ = ['ViewerCreator']
 
@@ -21,33 +20,23 @@ class ViewerCreator(ViewerCreator):
         # and label (what appears in dropdown and the default label of the viewer)
 
         if self.app._jdaviz_helper is not None:
-            phase_viewers = [{'name': 'lcviz-phase-viewer', 'label': f'flux-vs-phase:{e}'}
+            phase_viewers = [{'name': f'lcviz-phase-viewer:{e}', 'label': f'flux-vs-phase:{e}'}
                               for e in self.app._jdaviz_helper.plugins['Ephemeris'].component.choices]  # noqa
         else:
             phase_viewers = []
 
         self.viewer_types = [v for v in self.viewer_types if v['name'].startswith('lcviz')
-                             and v['label'] != 'flux-vs-phase'] + phase_viewers
+                             and not v['label'].startswith('flux-vs-phase')] + phase_viewers
+        self.send_state('viewer_types')
 
     def vue_create_viewer(self, name):
-        for viewer_item in self.viewer_types:
-            if viewer_item['name'] == name:
-                label = viewer_item['label']
-                break
-        else:
-            label = viewer_registry.members[name]['label']
-
-        if label in self.app._jdaviz_helper.viewers:
-            # clone whenever possible
-            # TODO: update this to not rely directly on the label for phase-viewers, but rather
-            # checking for the same ephemeris
-            self.app._jdaviz_helper.viewers[label]._obj.clone_viewer()
-            return
-
-        if name == 'lcviz-phase-viewer':
-            ephem_comp = ephem_component_from_phase_viewer_name(label)
+        if name.startswith('lcviz-phase-viewer') or name.startswith('flux-vs-phase'):
+            ephem_comp = name.split(':')[1]
             ephem_plg = self.app._jdaviz_helper.plugins['Ephemeris']
             ephem_plg.create_phase_viewer(ephem_comp)
             return
+        if name == 'flux-vs-time':
+            # allow passing label and map to the name for upstream support
+            name = 'lcviz-time-viewer'
 
         super().vue_create_viewer(name)

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -70,7 +70,7 @@ def test_synthetic_lc(helper):
 def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
     lc = light_curve_like_kepler_quarter
     helper.load_data(lc)
-    viewer = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    viewer = helper.default_time_viewer._obj
     subset_plugin = helper.plugins['Subset Tools']
 
     # the min/max of temporal regions can be defined in two ways:
@@ -95,7 +95,7 @@ def test_apply_xrangerois(helper, light_curve_like_kepler_quarter):
 def test_apply_yrangerois(helper, light_curve_like_kepler_quarter):
     lc = light_curve_like_kepler_quarter
     helper.load_data(lc)
-    viewer = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    viewer = helper.default_time_viewer._obj
     subset_plugin = helper.plugins['Subset Tools']
 
     subset_plugin._obj.subset_selected = "Create New"

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -21,7 +21,7 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
 def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
-    tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    tv = helper.default_time_viewer._obj
 
     b = helper.plugins['Binning']
     b._obj.plugin_opened = True

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -32,7 +32,7 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     with b.as_active():
         assert b.ephemeris == 'No ephemeris'
         assert len(_get_marks_from_viewer(tv)) == 1
-        assert len(_get_marks_from_viewer(pv)) == 0
+        assert len(_get_marks_from_viewer(pv)) == 1
         assert b._obj.ephemeris_dict == {}
 
         # update ephemeris will force re-phasing

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -118,9 +118,9 @@ def test_create_phase_viewer(helper, light_curve_like_kepler_quarter):
     ephem = helper.plugins['Ephemeris']
     vc = helper._tray_tools['lcviz-viewer-creator']
 
-    assert len(vc.viewer_types) == 1  # just time viewer
+    assert len(vc.viewer_types) == 2  # time viewer, phase viewer for default
     _ = ephem.create_phase_viewer()
-    assert len(vc.viewer_types) == 2
+    assert len(ephem._obj._get_phase_viewers()) == 1
 
     vc.vue_create_viewer('flux-vs-phase:default')
     assert len(ephem._obj._get_phase_viewers()) == 2
@@ -134,3 +134,6 @@ def test_create_phase_viewer(helper, light_curve_like_kepler_quarter):
 
     for pv in ephem._obj._get_phase_viewers():
         assert pv._ephemeris_component == 'renamed'
+
+    ephem.add_component('new')
+    assert len(vc.viewer_types) == 3

--- a/lcviz/tests/test_plugin_flatten.py
+++ b/lcviz/tests/test_plugin_flatten.py
@@ -25,7 +25,7 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
 def test_plugin_flatten(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
-    tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    tv = helper.default_time_viewer._obj
 
     ephem = helper.plugins['Ephemeris']
     pv = ephem.create_phase_viewer()._obj

--- a/lcviz/tests/test_plugin_frequency_analysis.py
+++ b/lcviz/tests/test_plugin_frequency_analysis.py
@@ -19,7 +19,6 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
 def test_plugin_frequency_analysis(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
-    # tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
 
     freq = helper.plugins['Frequency Analysis']
     freq.open_in_tray()

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -35,7 +35,7 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
 def test_plugin_markers(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
-    tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    tv = helper.default_time_viewer._obj
 
     mp = helper.plugins['Markers']
     label_mouseover = mp._obj.coords_info

--- a/lcviz/tests/test_translator.py
+++ b/lcviz/tests/test_translator.py
@@ -72,9 +72,7 @@ def test_round_trip(helper):
         '2009-05-02 03:52'
     ], format='iso')
 
-    viewer = helper.app.get_viewer(
-        helper._default_time_viewer_reference_name
-    )
+    viewer = helper.default_time_viewer._obj
     viewer.apply_roi(XRangeROI(*near_transit))
 
     columns_to_check = ['time', 'flux', 'flux_err']

--- a/lcviz/tests/test_tray_viewer_creator.py
+++ b/lcviz/tests/test_tray_viewer_creator.py
@@ -1,0 +1,9 @@
+def test_tray_viewer_creator(helper, light_curve_like_kepler_quarter):
+    # additional coverage in test_plugin_ephemeris
+    helper.load_data(light_curve_like_kepler_quarter)
+    vc = helper._tray_tools['lcviz-viewer-creator']
+
+    assert len(helper.viewers) == 1
+    assert len(vc.viewer_types) == 2  # time and default phase
+    vc.vue_create_viewer('flux-vs-time')
+    assert len(helper.viewers) == 2

--- a/lcviz/tests/test_viewers.py
+++ b/lcviz/tests/test_viewers.py
@@ -23,7 +23,7 @@ def test_clone(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
 
     def_viewer = helper.viewers['flux-vs-time']
-    assert def_viewer._obj._get_clone_viewer_reference() == 'flux-vs-time[1]'
+    assert helper._get_clone_viewer_reference(def_viewer._obj.reference) == 'flux-vs-time[1]'
 
     new_viewer = def_viewer._obj.clone_viewer()
-    assert new_viewer._obj._get_clone_viewer_reference() == 'flux-vs-time[2]'
+    assert helper._get_clone_viewer_reference(new_viewer._obj.reference) == 'flux-vs-time[2]'

--- a/lcviz/tests/test_viewers.py
+++ b/lcviz/tests/test_viewers.py
@@ -1,7 +1,7 @@
 
 def test_reset_limits(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
-    tv = helper.app.get_viewer(helper._default_time_viewer_reference_name)
+    tv = helper.default_time_viewer._obj
 
     orig_xlims = (tv.state.x_min, tv.state.x_max)
     orig_ylims = (tv.state.y_min, tv.state.y_max)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -20,7 +20,11 @@ from lcviz.state import ScatterViewerState
 from lightkurve import LightCurve
 
 
-__all__ = ['TimeScatterView', 'PhaseScatterView']
+__all__ = ['TimeScatterView', 'PhaseScatterView', 'ephem_component_from_phase_viewer_name']
+
+
+def ephem_component_from_phase_viewer_name(label):
+    return label.split('[')[0].split(':')[-1]
 
 
 @viewer_registry("lcviz-time-viewer", label="flux-vs-time")
@@ -249,7 +253,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
 class PhaseScatterView(TimeScatterView):
     @property
     def ephemeris_component(self):
-        return self.reference.split('[')[0].split(':')[-1]
+        return ephem_component_from_phase_viewer_name(self.reference)
 
     def _set_plot_x_axes(self, dc, component_labels, light_curve):
         # setting of y_att will be handled by ephemeris plugin

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -245,7 +245,7 @@ class TimeScatterView(JdavizViewerMixin, BqplotScatterView):
         return new_viewer.user_api
 
 
-@viewer_registry("lcviz-phase-viewer", label="phase-vs-time")
+@viewer_registry("lcviz-phase-viewer", label="flux-vs-phase")
 class PhaseScatterView(TimeScatterView):
     @property
     def ephemeris_component(self):


### PR DESCRIPTION
**NOTE**: this should be tested with jdaviz 3.8.x since this does not include updates for jdaviz 3.9 covered in #68.

This adds a viewer creator dropdown in the app-level toolbar which can create viewers, including phase viewers attached to a specific ephemeris.


https://github.com/spacetelescope/lcviz/assets/877591/c29ab69a-c3d6-4305-b860-d8ff484b864f




~The current behavior is to first check for an existing viewer with a matching label and if it exists, _clone_ the existing viewer (keeping data visibilities and plot options, etc), and otherwise create a new viewer.~

TODO:
- [x] testing with renaming ephemeris
- [x] either here or follow-up: move ephemeris logic into viewer metadata instead of relying on viewer label 
- [x] decide whether to allow all time viewers to be closed (and if so, test layer-visibility logic assumptions for new phase viewers)
- [x] upstream support for automatically opening data menu on blank viewer: https://github.com/spacetelescope/jdaviz/pull/2742 

Once merged:
- [ ] rebase the 3.9-updates and TPF feature branch on top of main and add support for image viewers (might require fixing clone support first)
- [ ] design and create ticket for what to show when no viewers exist?

The styling will also be improved by upstream https://github.com/spacetelescope/jdaviz/pull/2743