### PR TITLE
TST: Ignore DeprecationWarning in Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ filterwarnings = [
     "ignore:numpy\\.ndarray size changed:RuntimeWarning",
     "ignore:zmq\\.eventloop\\.ioloop is deprecated in pyzmq:DeprecationWarning",
     "ignore:((.|\n)*)Sentinel is not a public part of the traitlets API((.|\n)*)",
+    "ignore:datetime\\.datetime\\.utcfromtimestamp:DeprecationWarning",
     "ignore::DeprecationWarning:glue",
     "ignore::DeprecationWarning:bqplot",
     "ignore::DeprecationWarning:bqplot_image_gl",


### PR DESCRIPTION
This warning pops up when you run the test suite in Python 3.12. We can ignore it here.