### PR TITLE
temporarily remove jdaviz from devdeps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
+    # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
+    # to devdeps in tox.ini
     "jdaviz==3.8.*",
     "lightkurve>=2.4.1",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     devdeps: astropy>=0.0.dev0
     devdeps: scipy>=0.0.dev0
     devdeps: numpy>=0.0.dev0
-    devdeps: git+https://github.com/spacetelescope/jdaviz.git
+#    devdeps: git+https://github.com/spacetelescope/jdaviz.git
     devdeps: git+https://github.com/lightkurve/lightkurve.git
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
We're currently pinning a minor version of jdaviz and handling updates manually, so want to test that version of jdaviz with other devdeps (so a break caused by jdaviz does not prevent us from testing the other devdeps).  Updating the pin to the next minor version of jdaviz is currently handled by PRs that bump the version and apply any necessary changes (i.e. #68) which will then ensure tests pass before bumping the minor version of jdaviz.

If we ever stop tagging a specific minor version, dev tests for jdaviz should be re-introduced (as mentioned in the added comment in `pyproject.toml`)