### PR TITLE
jdaviz 3.10 updates

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -51,24 +51,24 @@ jobs:
             toxposargs: --remote-data
             allow_failure: false
 
-          - name: OS X - Python 3.9
+          - name: OS X - Python 3.10
             os: macos-latest
-            python: 3.9
-            toxenv: py39-test
+            python: '3.10'
+            toxenv: py310-test
             allow_failure: false
 
-          - name: Windows - Python 3.9
+          - name: Windows - Python 3.11
             os: windows-latest
-            python: 3.9
-            toxenv: py39-test
+            python: 3.11
+            toxenv: py311-test
             allow_failure: false
 
           # This also runs on cron but we want to make sure new changes
           # won't break this job at the PR stage.
-          - name: Python 3.11 with latest dev versions of key dependencies, and remote data
+          - name: Python 3.12 with latest dev versions of key dependencies, and remote data
             os: ubuntu-latest
-            python: '3.11'
-            toxenv: py311-test-devdeps
+            python: '3.12'
+            toxenv: py312-test-devdeps
             toxposargs: --remote-data --run-slow
             allow_failure: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.10'
 
     - name: Install python-build and twine
       run: python -m pip install build "twine>=3.3"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.0 (unreleased)
 ------------------
 
-* Updates to use jdaviz 3.10. [#105]
+* Updates to use jdaviz 3.10, which now requires python 3.10+. [#105]
 
 * Support loading, viewing, and slicing through TPF data cubes. [#82, #117]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.4.0 (unreleased)
 ------------------
 
+* Updates to use jdaviz 3.10. [#105]
+
+* Support loading, viewing, and slicing through TPF data cubes. [#82, #117]
+
 * Support loading, viewing, and slicing through TPF data cubes. [#82, #117, #118]
 
 * Default data labels no longer include flux-origin, but do include quarter/campaign/sector. [#111]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,7 @@ Common Issues
 If you encounter problems while following these installation instructions,
 please consult :ref:`known installation issues <known_issues_installation>`.
 
-Note that ``lcviz`` requires Python 3.9 or newer. If your ``pip`` corresponds to an older version of
+Note that ``lcviz`` requires Python 3.10 or newer. If your ``pip`` corresponds to an older version of
 Python, it will raise an error that it cannot find a valid package.
 
 Users occasionally encounter problems running the pure ``pip`` install above. For those

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -4,12 +4,27 @@ import os
 
 from lightkurve import LightCurve
 
+from glue.config import settings as glue_settings
 from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
+from glue.core.units import unit_converter
 from jdaviz.core.helpers import ConfigHelper
 from lcviz.viewers import TimeScatterView
 
 __all__ = ['LCviz']
+
+
+@unit_converter('custom-lcviz')
+class UnitConverter:
+    def equivalent_units(self, data, cid, units):
+        return set(list(map(str, u.Unit(units).find_equivalent_units(
+                    include_prefix_units=True, equivalencies=u.spectral()))))
+
+    def to_unit(self, data, cid, values, original_units, target_units):
+        return (values * u.Unit(original_units)).to_value(u.Unit(target_units))
+
+
+glue_settings.UNIT_CONVERTER = 'custom-lcviz'
 
 custom_components = {'plugin-ephemeris-select': 'components/plugin_ephemeris_select.vue'}
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -17,10 +17,12 @@ __all__ = ['LCviz']
 @unit_converter('custom-lcviz')
 class UnitConverter:
     def equivalent_units(self, data, cid, units):
-        return set(list(map(str, u.Unit(units).find_equivalent_units(
-                    include_prefix_units=True, equivalencies=u.spectral()))))
+        return set(list(map(str, u.Unit(units).find_equivalent_units(include_prefix_units=True))))
 
     def to_unit(self, data, cid, values, original_units, target_units):
+        # for some reason, glue is trying to request a change for cid='flux' from d to electron / s
+        if target_units not in self.equivalent_units(data, cid, original_units):
+            return values
         return (values * u.Unit(original_units)).to_value(u.Unit(target_units))
 
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -78,7 +78,7 @@ def _get_display_unit(app, axis):
     if app._jdaviz_helper is None or app._jdaviz_helper.plugins.get('Unit Conversion') is None:  # noqa
         # fallback on native units (unit conversion is not enabled)
         if axis == 'time':
-            return u.dimensionless_unscaled
+            return u.d
         elif axis == 'flux':
             return app._jdaviz_helper.default_time_viewer._obj.data()[0].flux.unit
         else:

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -194,7 +194,11 @@ class CoordsInfo(CoordsInfo):
             self.icon = 'mdi-cursor-default'
             self._dict['data_label'] = ''
         else:
-            time = viewer.slice_value
+            try:
+                time = viewer.slice_value
+            except IndexError:
+                self._viewer_mouse_clear_event(viewer)
+                return
             # TODO: store slice unit within image viewer to avoid this assumption?
             time_unit = str(self.app._jdaviz_helper.default_time_viewer._obj.time_unit)
             self.row2_title = 'Time'

--- a/lcviz/plugins/time_selector/time_selector.py
+++ b/lcviz/plugins/time_selector/time_selector.py
@@ -47,7 +47,7 @@ class TimeSelector(Slice):
                                    handler=self._on_ephemeris_changed)
 
     @property
-    def slice_axis(self):
+    def slice_display_unit_name(self):
         # global display unit "axis" corresponding to the slice axis
         return 'time'
 

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -146,17 +146,18 @@ def test_tpf_markers(helper, light_curve_like_kepler_quarter):
                                         {'event': 'mousemove',
                                          'domain': {'x': 0, 'y': 0}})
 
-    assert label_mouseover.as_text() == ('Pixel x=00000.0 y=00000.0 Value +1.28035e+01 electron / s',  # noqa
-                                         'Time 47.00689 d',
+    assert label_mouseover.as_text() == ('Pixel x=00000.0 y=00000.0 Value +1.27220e+00 electron / s',  # noqa
+                                         'Time 47.00000 d',
                                          '')
 
+    print(label_mouseover.as_dict())
     _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'KIC 1429092[TPF]',
-                                                      'time': 47.00688790508866,
+                                                      'time': 47.00000,
                                                       'time:unit': 'd',
                                                       'pixel': (0.0, 0.0),
                                                       'axes_x': 0,
                                                       'axes_x:unit': 'pix',
                                                       'axes_y': 0,
                                                       'axes_y:unit': 'pix',
-                                                      'value': 12.803528785705566,
+                                                      'value': 1.272199273109436,
                                                       'value:unit': 'electron / s'})

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -103,6 +103,10 @@ class TimeScatterView(JdavizViewerMixin, CloneViewerMixin, WithSliceIndicator, B
         # calling data_collection_item.get_component(slice_component_label) must work
         return 'dt'
 
+    @property
+    def slice_display_unit_name(self):
+        return 'time'
+
     def data(self, cls=None):
         data = []
 
@@ -333,6 +337,10 @@ class CubeView(CloneViewerMixin, CubevizImageView, WithSliceSelection):
     def slice_index(self):
         # index in viewer.slices corresponding to the slice axis
         return 0
+
+    @property
+    def slice_display_unit_name(self):
+        return 'time'
 
     def _initial_x_axis(self, *args):
         # Make sure that the x_att/y_att is correct on data load

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "astropy>=5.2",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz==3.10.*",
+    "jdaviz>=3.10.2,<3.11",
     "lightkurve>=2.4.1",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lcviz"
 description = "A Jdaviz-based light curve analysis and visualization tool"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "JDADF Developers", email = "kconroy@stsci.edu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "glue-core<1.19.0",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
     "jdaviz==3.10.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "glue-core<1.19.0",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz==3.9.*",
+    "jdaviz@git+https://github.com/spacetelescope/jdaviz",
     "lightkurve>=2.4.1",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "glue-core<1.19.0",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz@git+https://github.com/spacetelescope/jdaviz",
+    "jdaviz==3.10.*",
     "lightkurve>=2.4.1",
 ]
 dynamic = [


### PR DESCRIPTION
* Updates to handle changes in https://github.com/spacetelescope/jdaviz/pull/2758
* Requires https://github.com/spacetelescope/jdaviz/pull/2895 (will be included in 3.10.2)


**TODO**:
- [x] fix loading TPF images
- [x] fix initial slice in time viewer to be middle of light curve


**Waiting for**: jdaviz 3.10.2 (update pin in pyproject once released)

Closes #110