### PR TITLE
metadata: monkeypatch Undefined to show as empty string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 * Support loading, viewing, and slicing through TPF data cubes. [#82]
+* Metdata plugin: show undefined entries as empty string instead of object repr. [#108]
 
 0.3.0 - (04-05-2024)
 --------------------

--- a/lcviz/plugins/metadata_viewer/metadata_viewer.py
+++ b/lcviz/plugins/metadata_viewer/metadata_viewer.py
@@ -1,7 +1,14 @@
+from astropy.io.fits.card import Undefined
+
 from jdaviz.configs.default.plugins import MetadataViewer
 from jdaviz.core.registries import tray_registry
 
 __all__ = ['MetadataViewer']
+
+
+# monkeypatch astropy.io.fits.card.Undefined to show an empty string
+# instead of '<astropy.io.fits.card.Undefined object at 0x29f5b94d0>'
+Undefined.__str__ = lambda x: ''
 
 
 @tray_registry('lcviz-metadata-viewer', label="Metadata")


### PR DESCRIPTION
This PR closes #88 by monkeypatching the string representation of `astropy.io.fits.card.Undefined` to show an empty string in the metadata plugin instead of something like `<astropy.io.fits.card.Undefined object at 0x29f5b94d0>`