### PR TITLE
temporarily avoid conflicts introduced by recent glue releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
+    "glue-core<1.19.0",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
     "jdaviz==3.9.*",


### PR DESCRIPTION
with glue >= 1.19.0, we are getting the following traceback when loading data:

```
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/viewers/image/state.py:607: in _update_attribute_display_unit_choices
    self.attribute_display_unit = component.units
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/echo/core.py:263: in __setattr__
    self._notify_global(**{attribute: value})
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/utils/matplotlib.py:170: in wrapper
    return func(*args, **kwargs)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/viewers/matplotlib/state.py:319: in _notify_global
    super(MatplotlibLayerState, self)._notify_global(*args, **kwargs)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/echo/core.py:258: in _notify_global
    callback(**kwargs)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/core/state_objects.py:206: in _update_values
    self.update_values(**properties)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/core/state_objects.py:346: in update_values
    limits_native = converter.to_native(self.data,
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/core/units.py:40: in to_native
    return self.converter_helper.to_unit(data, cid, values, original_units, target_units)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/jdaviz/app.py:98: in to_unit
    spec = data.get_object(cls=Spectrum1D)
../../.tox/py310-test-alldeps-cov/lib/python3.10/site-packages/glue/core/data.py:298: in get_object
    return handler.to_object(self, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <glue_astronomy.translators.spectrum1d.Specutils1DHandler object at 0x7fd9cf37ccd0>
data_or_subset = Data (label: contents[pdcsap_flux]), attribute = None
statistic = None

    def to_object(self, data_or_subset, attribute=None, statistic='mean'):
        """
        Convert a glue Data object to a Spectrum1D object.
    
        Parameters
        ----------
        data_or_subset : `glue.core.data.Data` or `glue.core.subset.Subset`
            The data to convert to a Spectrum1D object
        attribute : `glue.core.component_id.ComponentID`
            The attribute to use for the Spectrum1D data
        statistic : {'minimum', 'maximum', 'mean', 'median', 'sum', 'percentile'}
            The statistic to use to collapse the dataset
        """
    
        if isinstance(data_or_subset, Subset):
            data = data_or_subset.data
            subset_state = data_or_subset.subset_state
        else:
            data = data_or_subset
            subset_state = None
    
        if data.ndim < 2 and statistic is not None:
            statistic = None
    
        if statistic is None and isinstance(data.coords, BaseHighLevelWCS):
    
            if isinstance(data.coords, PaddedSpectrumWCS):
                kwargs = {'wcs': data.coords.spectral_wcs}
            else:
                kwargs = {'wcs': data.coords}
    
        elif statistic is not None:
    
            if isinstance(data.coords, PaddedSpectrumWCS):
                spec_axis = 0
                axes = tuple(range(0, data.ndim-1))
                kwargs = {'wcs': data.coords.spectral_wcs}
            elif isinstance(data.coords, WCS):
    
                # Find spectral axis
                spec_axis = data.coords.naxis - 1 - data.coords.wcs.spec
    
                # Find non-spectral axes
                axes = tuple(i for i in range(data.ndim) if i != spec_axis)
    
                kwargs = {'wcs': data.coords.sub([WCSSUB_SPECTRAL])}
    
            else:
                raise ValueError('Can only use statistic= if the Data object has a FITS WCS')
    
        elif isinstance(data.coords, SpectralCoordinates):
    
            kwargs = {'spectral_axis': data.coords.spectral_axis}
    
        else:
>           raise TypeError('data.coords should be an instance of WCS '
                            'or SpectralCoordinates')
E           TypeError: data.coords should be an instance of WCS or SpectralCoordinates
```