### PR TITLE
Fix compatibility with glue 1.19+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 
 * Raise error when parser can't identify file_obj [#106]
 
+* Fixes compatibility with glue >= 1.19. [#109, #110]
+
 0.3.0 (04-05-2024)
 --------------------
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -4,12 +4,27 @@ import os
 
 from lightkurve import LightCurve
 
+from glue.config import settings as glue_settings
 from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
+from glue.core.units import unit_converter
 from jdaviz.core.helpers import ConfigHelper
 from lcviz.viewers import TimeScatterView
 
 __all__ = ['LCviz']
+
+
+@unit_converter('custom-lcviz')
+class UnitConverter:
+    def equivalent_units(self, data, cid, units):
+        return set(list(map(str, u.Unit(units).find_equivalent_units(
+                    include_prefix_units=True, equivalencies=u.spectral()))))
+
+    def to_unit(self, data, cid, values, original_units, target_units):
+        return (values * u.Unit(original_units)).to_value(u.Unit(target_units))
+
+
+glue_settings.UNIT_CONVERTER = 'custom-lcviz'
 
 custom_components = {'plugin-ephemeris-select': 'components/plugin_ephemeris_select.vue'}
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -22,6 +22,7 @@ class UnitConverter:
     def to_unit(self, data, cid, values, original_units, target_units):
         # for some reason, glue is trying to request a change for cid='flux' from d to electron / s
         if target_units not in self.equivalent_units(data, cid, original_units):
+            raise ValueError(f"to_unit cannot convert units, cid={cid}, original_units={original_units}, target_units={target_units}, values={values}")  # noqa
             return values
         return (values * u.Unit(original_units)).to_value(u.Unit(target_units))
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -17,10 +17,12 @@ __all__ = ['LCviz']
 @unit_converter('custom-lcviz')
 class UnitConverter:
     def equivalent_units(self, data, cid, units):
-        return set(list(map(str, u.Unit(units).find_equivalent_units(
-                    include_prefix_units=True, equivalencies=u.spectral()))))
+        return set(list(map(str, u.Unit(units).find_equivalent_units(include_prefix_units=True))))
 
     def to_unit(self, data, cid, values, original_units, target_units):
+        # for some reason, glue is trying to request a change for cid='flux' from d to electron / s
+        if target_units not in self.equivalent_units(data, cid, original_units):
+            return values
         return (values * u.Unit(original_units)).to_value(u.Unit(target_units))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
 ]
 dependencies = [
     "astropy>=5.2",
-    "glue-core<1.19.0",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
     "jdaviz==3.9.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "astropy>=5.2",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz==3.9.*",
+    "jdaviz>=3.9.1,<3.10.0",
     "lightkurve>=2.4.1",
 ]
 dynamic = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "astropy>=5.2",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz>=3.9.1,<3.10.0",
+    "jdaviz==3.9.*",
     "lightkurve>=2.4.1",
 ]
 dynamic = [


### PR DESCRIPTION
Reverts spacetelescope/lcviz#109

Not sure (yet) if this needs upstream fixes (glue and/or jdaviz) or extra handling here to ensure `to_object` goes through `lightkurve` instead of `specutils`.

~**Waiting for**: jdaviz 3.9.1~