### PR TITLE
replace flux-origin with quarter/campaign/sector in data_label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 * Support loading, viewing, and slicing through TPF data cubes. [#82]
 
+* Default data labels no longer include flux-origin, but do include quarter/campaign/sector. [#111]
+
 0.3.1 - unreleased
 ------------------
 

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -37,11 +37,16 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         new_data_label = light_curve.meta.get('OBJECT', 'Light curve')
 
     # handle flux_origin default
+    mission = light_curve.meta.get('MISSION', '')
     flux_origin = light_curve.meta.get('FLUX_ORIGIN', None)  # i.e. PDCSAP or SAP
     if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
         new_data_label += '[TPF]'
-    elif flux_origin is not None:
-        new_data_label += f'[{flux_origin}]'
+    elif mission == 'Kepler':
+        new_data_label += f' Q{light_curve.meta.get("QUARTER")}'
+    elif mission == 'k2':
+        new_data_label += f' C{light_curve.meta.get("CAMPAIGN")}'
+    elif mission == 'tess':
+        new_data_label += f' S{light_curve.meta.get("SECTOR")}'
 
     if flux_origin == 'flux' or (flux_origin is None and 'flux' in getattr(light_curve, 'columns', [])):  # noqa
         # then make a copy of this column so it won't be lost when changing with the flux_column

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -37,11 +37,11 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         new_data_label = light_curve.meta.get('OBJECT', 'Light curve')
 
     # handle flux_origin default
-    mission = light_curve.meta.get('MISSION', '')
+    mission = light_curve.meta.get('MISSION', '').lower()
     flux_origin = light_curve.meta.get('FLUX_ORIGIN', None)  # i.e. PDCSAP or SAP
     if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
         new_data_label += '[TPF]'
-    elif mission == 'Kepler':
+    elif mission == 'kepler':
         new_data_label += f' Q{light_curve.meta.get("QUARTER")}'
     elif mission == 'k2':
         new_data_label += f' C{light_curve.meta.get("CAMPAIGN")}'


### PR DESCRIPTION
This PR modifies the default data_labels for light curves to _remove_ flux-origin (since that can now be changed later by the flux origin plugin) and _adds_ quarter/campaign/sector information.

Note that calling `stitch` before loading into lcviz, will result in the _last_ quarter/campaign/sector being adopted in the metadata and therefore into the data-label.  Is this something we should propose for changes upstream?

Also note: TPF data are still suffixed with `[TPF]` in this PR, although that could be changed now or in the future if desired.

Discussion points:
- [ ] syntax for the suffixes (currently is C/Q/S followed by the number)
