### PR TITLE
Better default TPF stretch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.0 (unreleased)
 ------------------
 
-* Support loading, viewing, and slicing through TPF data cubes. [#82]
+* Support loading, viewing, and slicing through TPF data cubes. [#82, #117]
 
 * Default data labels no longer include flux-origin, but do include quarter/campaign/sector. [#111]
 

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -4,6 +4,7 @@ from jdaviz.core.registries import data_parser_registry
 import lightkurve
 
 from lcviz.viewers import PhaseScatterView, TimeScatterView
+from lcviz.plugins.plot_options import PlotOptions
 
 __all__ = ["light_curve_parser"]
 
@@ -74,6 +75,11 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
                 app._on_new_viewer(NewViewerMessage(CubeView, data=None, sender=app),
                                    vid='image', name='image')
                 app.add_data_to_viewer('image', new_data_label)
+
+        # set TPF viewer's stretch to custom defaults:
+        plot_options_plugin = PlotOptions(app=app)
+        if plot_options_plugin is not None:
+            plot_options_plugin._default_tpf_stretch()
 
     else:
         if show_in_viewer:

--- a/lcviz/plugins/plot_options/plot_options.py
+++ b/lcviz/plugins/plot_options/plot_options.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from jdaviz.configs.default.plugins import PlotOptions
 from jdaviz.core.registries import tray_registry
 
@@ -30,6 +32,20 @@ class PlotOptions(PlotOptions):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#plot-options"
+
+    def _default_tpf_stretch(
+            self, vmin_percentile=5, vmax_percentile=99, tpf_viewer_reference='image'
+    ):
+        viewer = self.app.get_viewer(tpf_viewer_reference)
+        image = viewer.layers[0].get_image_data()
+        vmin, vmax = np.nanpercentile(
+            image, [vmin_percentile, vmax_percentile]
+        )
+
+        self.viewer_selected = tpf_viewer_reference
+        self.stretch_function_value = 'log'
+        self.stretch_vmin_value = vmin
+        self.stretch_vmax_value = vmax
 
     @property
     def user_api(self):


### PR DESCRIPTION
This PR gives a better default colormap stretch on TPF files. It sets vmin/vmax to the 5/99 percentile limits from the cube:

```python
from lightkurve import search_targetpixelfile, search_lightcurve
from lcviz import LCviz

target = 'TRAPPIST-1'
lc = search_lightcurve(target, mission="K2", cadence="long").download().normalize()
tpf = search_targetpixelfile(target, mission="K2", cadence="long").download()

# Load the light curve into LCviz:
lcviz = LCviz()
lcviz.load_data(lc)
lcviz.load_data(tpf)
lcviz.show()

viewer = lcviz.app.get_viewer('flux-vs-time')
viewer.state.y_min = 0.9
viewer.state.y_max = 1.2
```

<img width="1176" alt="Screen Shot 2024-04-26 at 12 45 46" src="https://github.com/spacetelescope/lcviz/assets/3497584/4dfd2aeb-bcc5-41ab-8483-1b5220cfc8c6">

I opted to put this stretch as a private method in `PlotOptions`, and call the method from the parser when a TPF is loaded. That keeps the diff small. Caveats: this approach won't work if we load more than one TPF into the `image` viewer.