### PR TITLE
exclude TPF from plugins that expect lcs as input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.0 (unreleased)
 ------------------
 
-* Support loading, viewing, and slicing through TPF data cubes. [#82, #117]
+* Support loading, viewing, and slicing through TPF data cubes. [#82, #117, #118]
 
 * Default data labels no longer include flux-origin, but do include quarter/campaign/sector. [#111]
 

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -17,6 +17,7 @@ from lcviz.marks import LivePreviewBinning
 from lcviz.parsers import _data_with_reftime
 from lcviz.viewers import TimeScatterView, PhaseScatterView
 from lcviz.components import EphemerisSelectMixin
+from lcviz.utils import is_not_tpf
 
 
 __all__ = ['Binning']
@@ -61,7 +62,7 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
         # https://github.com/spacetelescope/jdaviz/pull/2239
         def not_from_binning_plugin(data):
             return data.meta.get('Plugin', None) != self.__class__.__name__
-        self.dataset.add_filter(not_from_binning_plugin)
+        self.dataset.add_filter(not_from_binning_plugin, is_not_tpf)
 
         # TODO: viewer added also needs to repopulate marks
         self.hub.subscribe(self, ViewerAddedMessage, handler=self._on_add_viewer)

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -15,6 +15,7 @@ from lightkurve import periodogram, FoldedLightCurve
 
 from lcviz.events import EphemerisComponentChangedMessage, EphemerisChangedMessage
 from lcviz.viewers import PhaseScatterView
+from lcviz.utils import is_not_tpf
 
 __all__ = ['Ephemeris']
 
@@ -93,6 +94,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         self._ignore_ephem_change = False
         self._ephemerides = {}
         self._prev_wrap_at = _default_wrap_at
+
+        self.dataset.add_filter(is_not_tpf)
 
         self.component = EditableSelectPluginComponent(self,
                                                        name='ephemeris',

--- a/lcviz/plugins/flatten/flatten.py
+++ b/lcviz/plugins/flatten/flatten.py
@@ -14,7 +14,7 @@ from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.components import FluxColumnSelectMixin
 from lcviz.marks import LivePreviewTrend, LivePreviewFlattened
-from lcviz.utils import data_not_folded
+from lcviz.utils import data_not_folded, is_not_tpf
 from lcviz.viewers import TimeScatterView, PhaseScatterView
 from lcviz.parsers import _data_with_reftime
 
@@ -77,7 +77,8 @@ class Flatten(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin):
                                         'flux_label_invalid_msg')
 
         # do not support flattening data in phase-space
-        self.dataset.add_filter(data_not_folded)
+        # do not allow TPF as input
+        self.dataset.add_filter(data_not_folded, is_not_tpf)
 
         # marks do not exist for the new viewer, so force another update to compute and draw
         # those marks

--- a/lcviz/plugins/flux_column/flux_column.py
+++ b/lcviz/plugins/flux_column/flux_column.py
@@ -4,6 +4,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
 from jdaviz.core.user_api import PluginUserApi
 
 from lcviz.components import FluxColumnSelectMixin
+from lcviz.utils import is_not_tpf
 
 __all__ = ['FluxColumn']
 
@@ -27,6 +28,9 @@ class FluxColumn(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # NOTE: may eventually want to add support for choosing the column for TPFs
+        self.dataset.add_filter(is_not_tpf)
 
     @property
     def user_api(self):

--- a/lcviz/plugins/frequency_analysis/frequency_analysis.py
+++ b/lcviz/plugins/frequency_analysis/frequency_analysis.py
@@ -10,7 +10,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         DatasetSelectMixin, SelectPluginComponent, PlotMixin)
 from jdaviz.core.user_api import PluginUserApi
 
-from lcviz.utils import data_not_folded
+from lcviz.utils import data_not_folded, is_not_tpf
 
 
 __all__ = ['FrequencyAnalysis']
@@ -61,7 +61,7 @@ class FrequencyAnalysis(PluginTemplateMixin, DatasetSelectMixin, PlotMixin):
         self._ignore_auto_update = False
 
         # do not support data only in phase-space
-        self.dataset.add_filter(data_not_folded)
+        self.dataset.add_filter(data_not_folded, is_not_tpf)
 
         self.method = SelectPluginComponent(self,
                                             items='method_items',

--- a/lcviz/plugins/stitch/stitch.py
+++ b/lcviz/plugins/stitch/stitch.py
@@ -8,7 +8,7 @@ from jdaviz.core.template_mixin import (PluginTemplateMixin,
                                         with_spinner)
 from jdaviz.core.user_api import PluginUserApi
 
-from lcviz.utils import data_not_folded
+from lcviz.utils import data_not_folded, is_not_tpf
 
 __all__ = ['Stitch']
 
@@ -41,7 +41,8 @@ class Stitch(PluginTemplateMixin, DatasetMultiSelectMixin, AddResultsMixin):
 
         self.dataset.multiselect = True
         # do not support stitching data in phase-space
-        self.dataset.add_filter(data_not_folded)
+        # do not allow TPF as input
+        self.dataset.add_filter(data_not_folded, is_not_tpf)
 
         self.results_label_default = 'stitched'
 

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -23,7 +23,9 @@ from astropy.time import Time
 from astropy.wcs.wcsapi.wrappers.base import BaseWCSWrapper
 from astropy.wcs.wcsapi import HighLevelWCSMixin
 
-__all__ = ['TimeCoordinates', 'LightCurveHandler', 'data_not_folded', 'enable_hot_reloading']
+__all__ = ['TimeCoordinates', 'LightCurveHandler',
+           'data_not_folded', 'is_tpf', 'is_not_tpf',
+           'enable_hot_reloading']
 
 
 component_ids = {'dt': ComponentID('dt')}
@@ -501,3 +503,11 @@ class TessTPFHandler(TPFHandler):
 # plugin component filters
 def data_not_folded(data):
     return data.meta.get('_LCVIZ_EPHEMERIS', None) is None
+
+
+def is_tpf(data):
+    return len(data.shape) == 3
+
+
+def is_not_tpf(data):
+    return not is_tpf(data)


### PR DESCRIPTION
all plugins that expect light curves as input should now (as of #82 which is not included in 0.3.x) filter to exclude TPFs.