### PR TITLE
Prevent duplicate sub-interval data labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.5.0 (unreleased)
 ------------------
 
+* Prevent duplicate sub-intervals (quarter/sector/campaign) in data labels. [#120]
+
 0.4.1 (unreleased)
 ------------------
 

--- a/lcviz/conftest.py
+++ b/lcviz/conftest.py
@@ -37,6 +37,9 @@ def light_curve_like_kepler_quarter(seed=42):
     )
     lc['flux_alt'] = flux + 1
     lc['flux_alt_err'] = flux_err
+    lc.meta['MISSION'] = 'KEPLER'
+    lc.meta['QUARTER'] = 10
+
     return lc
 
 

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -37,28 +37,25 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
     else:
         raise NotImplementedError(f"could not parse light_curve with type {type(file_obj)}")
 
-    # make a data label:
-    if data_label is not None:
-        new_data_label = f'{data_label}'
-    else:
-        new_data_label = light_curve.meta.get('OBJECT', 'Light curve')
-
     # handle flux_origin default
     mission = light_curve.meta.get('MISSION', '').lower()
     flux_origin = light_curve.meta.get('FLUX_ORIGIN', None)  # i.e. PDCSAP or SAP
 
-    if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
-        new_data_label += '[TPF]'
-    elif mission in mission_sub_intervals:
-        # the sub-interval label is something like "Q9" for Kepler or
-        # "S9" for TESS. If it's already in the proposed data label, skip;
-        # otherwise, append it.
-        sub_interval_label = (
-            f'{mission_sub_intervals[mission]["prefix"]}'
-            f'{light_curve.meta.get(mission_sub_intervals[mission]["card"])}'
-        )
-        if sub_interval_label not in new_data_label:
-            new_data_label += f' [{sub_interval_label}]'
+    # make a data label:
+    if data_label is None:
+        data_label = light_curve.meta.get('OBJECT', 'Light curve')
+
+        if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
+            data_label += '[TPF]'
+        elif mission in mission_sub_intervals:
+            # the sub-interval label is something like "Q9" for Kepler or
+            # "S9" for TESS. If it's already in the proposed data label, skip;
+            # otherwise, append it.
+            sub_interval_label = (
+                f' [{mission_sub_intervals[mission]["prefix"]}'
+                f'{light_curve.meta.get(mission_sub_intervals[mission]["card"])}]'
+            )
+            data_label += sub_interval_label
 
     if flux_origin == 'flux' or (flux_origin is None and 'flux' in getattr(light_curve, 'columns', [])):  # noqa
         # then make a copy of this column so it won't be lost when changing with the flux_column
@@ -69,7 +66,7 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         light_curve.meta['FLUX_ORIGIN'] = 'flux:orig'
 
     data = _data_with_reftime(app, light_curve)
-    app.add_data(data, new_data_label)
+    app.add_data(data, data_label)
 
     if isinstance(light_curve, lightkurve.targetpixelfile.TargetPixelFile):
         # ensure an image/cube/TPF viewer exists
@@ -80,12 +77,12 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
             found_viewer = False
             for viewer_id, viewer in app._viewer_store.items():
                 if isinstance(viewer, CubeView):
-                    app.add_data_to_viewer(viewer_id, new_data_label)
+                    app.add_data_to_viewer(viewer_id, data_label)
                     found_viewer = True
             if not found_viewer:
                 app._on_new_viewer(NewViewerMessage(CubeView, data=None, sender=app),
                                    vid='image', name='image')
-                app.add_data_to_viewer('image', new_data_label)
+                app.add_data_to_viewer('image', data_label)
 
         # set TPF viewer's stretch to custom defaults:
         plot_options_plugin = PlotOptions(app=app)
@@ -96,13 +93,13 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
         if show_in_viewer:
             for viewer_id, viewer in app._viewer_store.items():
                 if isinstance(viewer, (TimeScatterView, PhaseScatterView)):
-                    app.add_data_to_viewer(viewer_id, new_data_label)
+                    app.add_data_to_viewer(viewer_id, data_label)
 
             # add to any known phase viewers
             ephem_plugin = app._jdaviz_helper.plugins.get('Ephemeris', None)
             if ephem_plugin is not None:
                 for viewer in ephem_plugin._obj._get_phase_viewers():
-                    app.add_data_to_viewer(viewer.reference, new_data_label)
+                    app.add_data_to_viewer(viewer.reference, data_label)
 
 
 def _data_with_reftime(app, light_curve):

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -119,3 +119,14 @@ def test_apply_yrangerois(helper, light_curve_like_kepler_quarter):
     subset_state = subsets['Subset 1'][0]['subset_state']
 
     np.testing.assert_allclose([subset_state.lo, subset_state.hi], [1, 1.05])
+
+
+def test_data_label(helper, light_curve_like_kepler_quarter):
+    # add data without specifying data label:
+    helper.load_data(light_curve_like_kepler_quarter)
+    assert helper.app.data_collection[-1].label == 'Light curve [Q10]'
+
+    # specify label with a quarter, check that quarter isn't appended:
+    data_label = 'Cool target in Q10'
+    helper.load_data(light_curve_like_kepler_quarter, data_label=data_label)
+    assert helper.app.data_collection[-1].label == data_label

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -126,7 +126,7 @@ def test_data_label(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     assert helper.app.data_collection[-1].label == 'Light curve [Q10]'
 
-    # specify label with a quarter, check that quarter isn't appended:
-    data_label = 'Cool target in Q10'
+    # specify label, check that quarter isn't appended:
+    data_label = 'Cool target'
     helper.load_data(light_curve_like_kepler_quarter, data_label=data_label)
     assert helper.app.data_collection[-1].label == data_label

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -51,7 +51,7 @@ def test_plugin_markers(helper, light_curve_like_kepler_quarter):
                                          'Time 5.45833e+00 d',
                                          'Flux 9.67587e-01')
 
-    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve',
+    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve [Q10]',
                                                       'time': 5.4583335,
                                                       'time:unit': 'd',
                                                       'phase': np.nan,
@@ -81,7 +81,7 @@ def test_plugin_markers(helper, light_curve_like_kepler_quarter):
                                          'Phase 0.45833',
                                          'Flux 9.67587e-01')
 
-    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve',
+    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve [Q10]',
                                                       'time': 5.458333374001086,
                                                       'time:unit': 'd',
                                                       'phase': 0.4583333730697632,

--- a/lcviz/tests/test_plugin_stitch.py
+++ b/lcviz/tests/test_plugin_stitch.py
@@ -5,7 +5,7 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
     lcviz.load_data(lc1, 'lc1')
     lcviz.load_data(lc2, 'lc2')
-    lcviz.app.add_data_to_viewer('flux-vs-time', 'lc2 [Q10]')
+    lcviz.app.add_data_to_viewer('flux-vs-time', 'lc2')
     # lcviz.show()
 
     stitch = lcviz.plugins['Stitch']
@@ -21,7 +21,7 @@ def test_plugin_stitch(helper, light_curve_like_kepler_quarter):
     assert "Stitch" not in helper.plugins.keys()
 
     helper.load_data(light_curve_like_kepler_quarter.copy(), 'lc2')
-    helper.app.add_data_to_viewer('flux-vs-time', 'lc2 [Q10]')
+    helper.app.add_data_to_viewer('flux-vs-time', 'lc2')
     assert "Stitch" in helper.plugins.keys()
 
     stitch = helper.plugins['Stitch']

--- a/lcviz/tests/test_plugin_stitch.py
+++ b/lcviz/tests/test_plugin_stitch.py
@@ -5,7 +5,7 @@ def test_docs_snippets(helper, light_curve_like_kepler_quarter):
 
     lcviz.load_data(lc1, 'lc1')
     lcviz.load_data(lc2, 'lc2')
-    lcviz.app.add_data_to_viewer('flux-vs-time', 'lc2')
+    lcviz.app.add_data_to_viewer('flux-vs-time', 'lc2 [Q10]')
     # lcviz.show()
 
     stitch = lcviz.plugins['Stitch']
@@ -21,7 +21,7 @@ def test_plugin_stitch(helper, light_curve_like_kepler_quarter):
     assert "Stitch" not in helper.plugins.keys()
 
     helper.load_data(light_curve_like_kepler_quarter.copy(), 'lc2')
-    helper.app.add_data_to_viewer('flux-vs-time', 'lc2')
+    helper.app.add_data_to_viewer('flux-vs-time', 'lc2 [Q10]')
     assert "Stitch" in helper.plugins.keys()
 
     stitch = helper.plugins['Stitch']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     # to devdeps in tox.ini
     "jdaviz>=3.10.2,<3.11",
     "lightkurve>=2.4.1",
+    "numpy<2",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
If you load Kepler data from Quarter 10 with a `data_label = "Target in Q10"`, the parser will happily add another "Q10" to the end of the data label [🐱](https://jira.stsci.edu/browse/JDAT-4565). This PR checks if the sub-interval for any mission is already in the data label, and only adds one if none is found.