### PR TITLE
fix CDIPS parsing support (column filled with strings)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 0.4.1 (unreleased)
 ------------------
 
+* Fixes CDIPS support by handling units stored as empty strings. [#122]
+
 0.4.0 (06-11-2024)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@
 0.4.1 (unreleased)
 ------------------
 
-* Fixes CDIPS support by handling units stored as empty strings. [#122]
+* Fixes CDIPS support by handling columns filled with strings with empty units. [#122]
 
 0.4.0 (06-11-2024)
 ------------------

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -281,8 +281,14 @@ class LightCurveHandler:
 
             if len(values) and isinstance(values[0], Time):
                 values = Time(values.base)
-            elif hasattr(component, 'units') and component.units not in ("None", ""):
-                values = u.Quantity(values, component.units)
+            elif hasattr(component, 'units') and component.units != "None":
+                try:
+                    values = u.Quantity(values, component.units)
+                except TypeError:
+                    if component.units != "":
+                        raise
+                    # values could have been an array of strings with units ""
+                    values = values
 
             if component_id.label not in names:
                 columns.append(values)

--- a/lcviz/utils.py
+++ b/lcviz/utils.py
@@ -281,7 +281,7 @@ class LightCurveHandler:
 
             if len(values) and isinstance(values[0], Time):
                 values = Time(values.base)
-            elif hasattr(component, 'units') and component.units != "None":
+            elif hasattr(component, 'units') and component.units not in ("None", ""):
                 values = u.Quantity(values, component.units)
 
             if component_id.label not in names:


### PR DESCRIPTION
which affected CDIPS HLSP light curves and prevented them from being loaded into lcviz.  Note that the time format is still incorrect, but that is a separate issue.