### PR TITLE
(temporarily) max pin numpy<2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 0.4.1 (unreleased)
 ------------------
 
+* Max pin numpy to to exclude 2.0 until full compatibility can be supported. [#126]
+
 * Fixes CDIPS support by handling columns filled with strings with empty units. [#122]
 
 0.4.0 (06-11-2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     # to devdeps in tox.ini
     "jdaviz>=3.10.2,<3.11",
     "lightkurve>=2.4.1",
+    "numpy<2",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
Was included in #120, but never backported.