### PR TITLE
Add methods for querying NASA Exoplanet Archive for ephemeris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 * Prevent duplicate sub-intervals (quarter/sector/campaign) in data labels. [#120]
 
+* Add feature to query the NASA Exoplanet Archive for exoplanet ephemerides. [#127]
+
 0.4.3 (unreleased)
 ------------------
 

--- a/lcviz/conftest.py
+++ b/lcviz/conftest.py
@@ -37,9 +37,15 @@ def light_curve_like_kepler_quarter(seed=42):
     )
     lc['flux_alt'] = flux + 1
     lc['flux_alt_err'] = flux_err
-    lc.meta['MISSION'] = 'KEPLER'
-    lc.meta['QUARTER'] = 10
-    lc.meta['OBJECT'] = 'HAT-P-11'
+    lc.meta.update(
+        {
+            'MISSION': 'KEPLER',
+            'QUARTER': 10,
+            'OBJECT': 'HAT-P-11',
+            'RA': 297.7101763,
+            'DEC': 48.0818635,
+        }
+    )
 
     return lc
 

--- a/lcviz/conftest.py
+++ b/lcviz/conftest.py
@@ -39,6 +39,7 @@ def light_curve_like_kepler_quarter(seed=42):
     lc['flux_alt_err'] = flux_err
     lc.meta['MISSION'] = 'KEPLER'
     lc.meta['QUARTER'] = 10
+    lc.meta['OBJECT'] = 'HAT-P-11'
 
     return lc
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -700,12 +700,12 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
 
     def adopt_from_catalog_in_new_viewer(self, *args):
         new_component_label = self.query_result_selected.replace(' ', '')
-        if len(self._get_phase_viewers(new_component_label)):
+        if new_component_label in self.component.choices:
             # warn the user that an ephemeris component already exists with this label,
             # a second won't be added:
             self.hub.broadcast(
                 SnackbarMessage(
-                    f"Ephemeris component {new_component_label} already exists, skipping",
+                    f"Ephemeris component {new_component_label} already exists, skipping.",
                     sender=self, color="warning"
                 )
             )

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -67,6 +67,19 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
       Dataset to use for determining the period.
     * ``method`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
       Method/algorithm to determine the period.
+    * :meth:`query_for_ephemeris`
+      Query the `NASA Exoplanet Archive <https://exoplanetarchive.ipac.caltech.edu/>`_'s
+      `Planetary System Composite Parameters
+      <https://exoplanetarchive.ipac.caltech.edu/docs/pscp_about.html>`_
+      table for the planet-hosting star identified
+      by the observation's header key "OBJECT", or if that fails,
+      by the observation's header keys for RA and Dec.
+    * ``query_result`` (:class:`~jdaviz.core.template_mixin.SelectPluginComponent`):
+      The name of a planet from a NASA Exoplanet Archive query, used for
+      adopting literature values for the orbital period and mid-transit time.
+    * :meth:`create_ephemeris_from_query`
+      Create an ephemeris component with the period and epoch from
+      the planet selected from the NASA Exoplanet Archive query in ``query_result``.
     """
     template_file = __file__, "ephemeris.vue"
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -158,7 +158,7 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             'times_to_phases', 'phases_to_times', 'get_data',
             'dataset', 'method', 'period_at_max_power',
             'adopt_period_at_max_power', 'query_for_ephemeris',
-            'query_result', 'adopt_from_catalog', 'create_ephemeris_from_query'
+            'query_result', 'create_ephemeris_from_query'
         ]
         return PluginUserApi(self, expose=expose)
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -627,7 +627,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         if self.query_name:
             # first query by object name:
             query_result = self.nasa_exoplanet_archive.query_object(
-                self.query_name, table='pscomppars'
+                object_name=self.query_name,
+                table='pscomppars'
             )
 
         if (
@@ -637,8 +638,9 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             # next query by coordinates:
             coord = SkyCoord(ra=self.query_ra, dec=self.query_dec, unit=u.deg)
             query_result = self.nasa_exoplanet_archive.query_region(
-                coord, self.query_radius * u.arcsec,
-                table='pscomppars'
+                table='pscomppars',
+                coordinates=coord,
+                radius=self.query_radius * u.arcsec,
             )
 
         if query_result is None or len(query_result) == 0:

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -695,9 +695,6 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             # otherwise, adopt the ephemeris in a new phase viewer:
             self.adopt_from_catalog_in_new_viewer()
 
-    def vue_adopt_from_catalog(self, *args):
-        self.adopt_from_catalog()
-
     def adopt_from_catalog_in_new_viewer(self, *args):
         new_component_label = self.query_result_selected.replace(' ', '')
         if new_component_label in self.component.choices:

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -245,7 +245,8 @@
             <v-row justify="end">
             <v-col>
               <plugin-action-button
-                @click="adopt_from_catalog_in_new_viewer">
+                @click="adopt_from_catalog_in_new_viewer"
+                :disabled="component_items.map(item => item.label).includes(query_result_selected.replace(/\s/g, ''))">
                   Create new component
               </plugin-action-button>
             </v-col>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -244,15 +244,9 @@
           <j-tooltip :tooltipcontent="'Adopt period and epoch into '+component_selected+' ephemeris.'">
             <v-row justify="end">
             <v-col>
-              <div v-if="phase_viewer_exists">
-                <plugin-action-button
-                  @click="adopt_from_catalog">
-                    Adopt in this viewer
-                </plugin-action-button>
-              </div>
               <plugin-action-button
                 @click="adopt_from_catalog_in_new_viewer">
-                  Adopt in a new viewer
+                  Create new component
               </plugin-action-button>
             </v-col>
             </v-row>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -67,7 +67,6 @@
           label="Period derivative"
           v-model.number="dpdt"
           :step="dpdt_step"
-          type="number"
           hint="The first time-derivative of the period of the ephemeris."
           persistent-hint
           :rules="[() => dpdt!=='' || 'This field is required']"
@@ -81,7 +80,6 @@
           label="Wrapping phase"
           v-model.number="wrap_at"
           :step="0.1"
-          type="number"
           :hint="'Phased data will encompass the range '+wrap_at_range+'.'"
           persistent-hint
           :rules="[() => wrap_at!=='' || 'This field is required']"
@@ -110,8 +108,6 @@
         ></v-select>
       </v-row>
 
-
-
       <div style="display: grid"> <!-- overlay container -->
         <div style="grid-area: 1/1">
 
@@ -120,7 +116,7 @@
           </v-row>
           <v-row v-else>
             <j-tooltip :tooltipcontent="'adopt period into '+component_selected+' ephemeris.'">
-              <v-btn text color='primary '@click='adopt_period_at_max_power' style="padding: 0px">
+              <v-btn text color='primary' @click='adopt_period_at_max_power' style="padding: 0px">
                 period: {{period_at_max_power}}
               </v-btn>
             </j-tooltip>
@@ -144,7 +140,71 @@
         </div>
       </div>
 
+      <j-plugin-section-header>Query NASA Exoplanet Archive</j-plugin-section-header>
+      <v-row>
+        <v-text-field
+          ref="query_name"
+          type="string"
+          label="Object name"
+          v-model.number="query_name"
+          hint="Object name."
+          persistent-hint
+        ></v-text-field>
+      </v-row>
+      <v-row>
+        <v-text-field
+          ref="query_ra"
+          type="number"
+          label="RA (degrees)"
+          v-model.number="query_ra"
+          :step="ra_dec_step"
+          hint="Object right ascension."
+          persistent-hint
+        ></v-text-field>
+      </v-row>
+      <v-row>
+        <v-text-field
+          ref="query_dec"
+          type="number"
+          label="Dec (degrees)"
+          v-model.number="query_dec"
+          :step="ra_dec_step"
+          hint="Object declination."
+          persistent-hint
+        ></v-text-field>
+      </v-row>
 
+      <v-row justify="end">
+        <j-tooltip tooltipcontent="Query for this object.">
+          <plugin-action-button
+            :spinner="query_spinner"
+            :results_isolated_to_plugin="false"
+            @click="query_for_ephemeris">
+              Query
+          </plugin-action-button>
+        </j-tooltip>
+      </v-row>
+      <div v-if="query_result_names.length > 0">
+        <v-row>
+          <v-select
+            :menu-props="{ left: true }"
+            attach
+            :items="query_result_names"
+            v-model="query_result_selected"
+            label="Ephemeris from query result"
+            :hint="'Ephemeris parameters from ' + query_result_names.length + ' available query result(s)'"
+            persistent-hint
+          ></v-select>
+        </v-row>
+
+        <v-row v-if="query_result_selected !== ''">
+          <j-tooltip :tooltipcontent="'Adopt period into '+component_selected+' ephemeris.'">
+            <v-btn text color='primary' @click='adopt_from_catalog' style="padding: 0px">
+              period: {{period_from_catalog}}, t0: {{t0_from_catalog}}
+            </v-btn>
+          </j-tooltip>
+        </v-row>
+      </div>
     </div>
 
   </j-tray-plugin>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -245,7 +245,7 @@
             <v-row justify="end">
             <v-col>
               <plugin-action-button
-                @click="adopt_from_catalog_in_new_viewer"
+                @click="create_ephemeris_from_query"
                 :disabled="component_items.map(item => item.label).includes(query_result_selected.replace(/\s/g, ''))">
                   Create new component
               </plugin-action-button>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -142,6 +142,17 @@
 
       <j-plugin-section-header>Query NASA Exoplanet Archive</j-plugin-section-header>
       <v-row>
+        <span class="v-messages v-messages__message text--secondary">
+          Query the
+          <a href="https://exoplanetarchive.ipac.caltech.edu/docs/pscp_about.html" target="_blank">
+          Planetary Systems Composite Data</a> table from
+          <a href="https://exoplanetarchive.ipac.caltech.edu/" target="_blank">
+          NASA Exoplanet Archive</a>. Queries first by name, then falls back on
+          coordinates if the object name is not recognized.
+        </span>
+      </v-row>
+
+      <v-row>
         <v-text-field
           ref="query_name"
           type="string"
@@ -173,6 +184,17 @@
           persistent-hint
         ></v-text-field>
       </v-row>
+      <v-row>
+        <v-text-field
+          ref="query_radius"
+          type="number"
+          label="Radius (arcseconds)"
+          v-model.number="query_radius"
+          :step="1"
+          hint="Radius around the query coordinate."
+          persistent-hint
+        ></v-text-field>
+      </v-row>
 
       <v-row justify="end">
         <j-tooltip tooltipcontent="Query for this object.">
@@ -184,24 +206,56 @@
           </plugin-action-button>
         </j-tooltip>
       </v-row>
-      <div v-if="query_result_names.length > 0">
+      <div v-if="query_result_items.length > 0">
         <v-row>
           <v-select
             :menu-props="{ left: true }"
             attach
-            :items="query_result_names"
+            :items="query_result_items"
+            :item-value="item => item.name"
             v-model="query_result_selected"
-            label="Ephemeris from query result"
-            :hint="'Ephemeris parameters from ' + query_result_names.length + ' available query result(s)'"
+            label="Ephemerides available"
+            :hint="'Ephemeris parameters from ' + query_result_items.length + ' available query result(s)'"
             persistent-hint
-          ></v-select>
+            dense
+          >
+
+          <template v-slot:selection="{ item }">
+            <span>
+              {{ item.name }}
+            </span>
+          </template>
+          <template v-slot:item="{ item }">
+            <span style="margin-top: 8px; margin-bottom: 0px">
+                {{ item.name }}
+              <v-row style="line-height: 1.0; margin: 0px; opacity: 0.85; font-size: 8pt">
+                Period: {{ item.period }} d, Epoch: {{ item.epoch }} d
+              </v-row>
+            </span>
+          </template>
+
+          </v-select>
         </v-row>
 
         <v-row v-if="query_result_selected !== ''">
-          <j-tooltip :tooltipcontent="'Adopt period into '+component_selected+' ephemeris.'">
-            <v-btn text color='primary' @click='adopt_from_catalog' style="padding: 0px">
-              period: {{period_from_catalog}}, t0: {{t0_from_catalog}}
-            </v-btn>
+          <span class="v-messages v-messages__message text--secondary">
+            Period: {{period_from_catalog}} d, Epoch: {{t0_from_catalog}} d
+          </span>
+          <j-tooltip :tooltipcontent="'Adopt period and epoch into '+component_selected+' ephemeris.'">
+            <v-row justify="end">
+            <v-col>
+              <div v-if="phase_viewer_exists">
+                <plugin-action-button
+                  @click="adopt_from_catalog">
+                    Adopt in this viewer
+                </plugin-action-button>
+              </div>
+              <plugin-action-button
+                @click="adopt_from_catalog_in_new_viewer">
+                  Adopt in a new viewer
+              </plugin-action-button>
+            </v-col>
+            </v-row>
           </j-tooltip>
         </v-row>
       </div>

--- a/lcviz/plugins/ephemeris/ephemeris.vue
+++ b/lcviz/plugins/ephemeris/ephemeris.vue
@@ -212,7 +212,7 @@
             :menu-props="{ left: true }"
             attach
             :items="query_result_items"
-            :item-value="item => item.name"
+            :item-value="item => item.label"
             v-model="query_result_selected"
             label="Ephemerides available"
             :hint="'Ephemeris parameters from ' + query_result_items.length + ' available query result(s)'"
@@ -222,12 +222,12 @@
 
           <template v-slot:selection="{ item }">
             <span>
-              {{ item.name }}
+              {{ item.label }}
             </span>
           </template>
           <template v-slot:item="{ item }">
             <span style="margin-top: 8px; margin-bottom: 0px">
-                {{ item.name }}
+                {{ item.label }}
               <v-row style="line-height: 1.0; margin: 0px; opacity: 0.85; font-size: 8pt">
                 Period: {{ item.period }} d, Epoch: {{ item.epoch }} d
               </v-row>

--- a/lcviz/tests/test_parser.py
+++ b/lcviz/tests/test_parser.py
@@ -124,7 +124,8 @@ def test_apply_yrangerois(helper, light_curve_like_kepler_quarter):
 def test_data_label(helper, light_curve_like_kepler_quarter):
     # add data without specifying data label:
     helper.load_data(light_curve_like_kepler_quarter)
-    assert helper.app.data_collection[-1].label == 'Light curve [Q10]'
+    object_name = helper.app.data_collection[-1].meta['OBJECT']
+    assert helper.app.data_collection[-1].label == f'{object_name} [Q10]'
 
     # specify label, check that quarter isn't appended:
     data_label = 'Cool target'

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -132,3 +132,25 @@ def test_create_phase_viewer(helper, light_curve_like_kepler_quarter):
 
     ephem.add_component('new')
     assert len(vc.viewer_types) == 3
+
+
+def test_ephemeris_queries(helper, light_curve_like_kepler_quarter):
+    helper.load_data(light_curve_like_kepler_quarter)
+    ephem = helper.plugins['Ephemeris']
+
+    ephem.query_for_ephemeris()
+    # this should be HAT-P-11 b:
+    planet = ephem.query_result.choices[0]
+    assert planet == 'HAT-P-11 b'
+
+    ephem.query_result = planet
+    ephem.adopt_from_catalog()
+
+    # compare against best/recent parameters:
+    period_yee_2018 = 4.88780244
+    assert abs(1 - period_yee_2018 / ephem.period) < 1e-3
+
+    epoch_kokori_2022 = 2455109.335119
+    ref_time = helper.app.data_collection[0].coords.reference_time.jd
+    expected_t0 = (epoch_kokori_2022 - ref_time) % period_yee_2018
+    assert abs(1 - expected_t0 / ephem.t0) < 1e-3

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -150,12 +150,11 @@ def test_ephemeris_queries(helper, light_curve_like_kepler_quarter):
     ephem = helper.plugins['Ephemeris']
 
     ephem.query_for_ephemeris()
-    # this should be HAT-P-11 b:
     planet = ephem.query_result.choices[0]
     assert planet == 'HAT-P-11 b'
 
     ephem.query_result = planet
-    ephem.adopt_from_catalog()
+    ephem.create_ephemeris_from_query()
 
     compare_against_literature_ephemeris(helper, ephem)
 
@@ -168,11 +167,10 @@ def test_ephemeris_query_no_name(helper, light_curve_like_kepler_quarter):
     ephem = helper.plugins['Ephemeris']
 
     ephem.query_for_ephemeris()
-    # this should be HAT-P-11 b:
     planet = ephem.query_result.choices[0]
     assert planet == 'HAT-P-11 b'
 
     ephem.query_result = planet
-    ephem.adopt_from_catalog()
+    ephem.create_ephemeris_from_query()
 
     compare_against_literature_ephemeris(helper, ephem)

--- a/lcviz/tests/test_plugin_ephemeris.py
+++ b/lcviz/tests/test_plugin_ephemeris.py
@@ -134,6 +134,17 @@ def test_create_phase_viewer(helper, light_curve_like_kepler_quarter):
     assert len(vc.viewer_types) == 3
 
 
+def compare_against_literature_ephemeris(helper, ephem):
+    # compare against best/recent parameters:
+    period_yee_2018 = 4.88780244
+    assert abs(1 - period_yee_2018 / ephem.period) < 1e-3
+
+    epoch_kokori_2022 = 2455109.335119
+    ref_time = helper.app.data_collection[0].coords.reference_time.jd
+    expected_t0 = (epoch_kokori_2022 - ref_time) % period_yee_2018
+    assert abs(1 - expected_t0 / ephem.t0) < 1e-3
+
+
 def test_ephemeris_queries(helper, light_curve_like_kepler_quarter):
     helper.load_data(light_curve_like_kepler_quarter)
     ephem = helper.plugins['Ephemeris']
@@ -146,11 +157,22 @@ def test_ephemeris_queries(helper, light_curve_like_kepler_quarter):
     ephem.query_result = planet
     ephem.adopt_from_catalog()
 
-    # compare against best/recent parameters:
-    period_yee_2018 = 4.88780244
-    assert abs(1 - period_yee_2018 / ephem.period) < 1e-3
+    compare_against_literature_ephemeris(helper, ephem)
 
-    epoch_kokori_2022 = 2455109.335119
-    ref_time = helper.app.data_collection[0].coords.reference_time.jd
-    expected_t0 = (epoch_kokori_2022 - ref_time) % period_yee_2018
-    assert abs(1 - expected_t0 / ephem.t0) < 1e-3
+
+def test_ephemeris_query_no_name(helper, light_curve_like_kepler_quarter):
+    # test that the query successfully falls back on the RA/Dec:
+    light_curve_like_kepler_quarter.meta['OBJECT'] = ''
+
+    helper.load_data(light_curve_like_kepler_quarter)
+    ephem = helper.plugins['Ephemeris']
+
+    ephem.query_for_ephemeris()
+    # this should be HAT-P-11 b:
+    planet = ephem.query_result.choices[0]
+    assert planet == 'HAT-P-11 b'
+
+    ephem.query_result = planet
+    ephem.adopt_from_catalog()
+
+    compare_against_literature_ephemeris(helper, ephem)

--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -51,7 +51,8 @@ def test_plugin_markers(helper, light_curve_like_kepler_quarter):
                                          'Time 5.45833e+00 d',
                                          'Flux 9.67587e-01')
 
-    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve [Q10]',
+    object_name = helper.app.data_collection[-1].meta['OBJECT']
+    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': f'{object_name} [Q10]',
                                                       'time': 5.4583335,
                                                       'time:unit': 'd',
                                                       'phase': np.nan,
@@ -81,7 +82,7 @@ def test_plugin_markers(helper, light_curve_like_kepler_quarter):
                                          'Phase 0.45833',
                                          'Flux 9.67587e-01')
 
-    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'Light curve [Q10]',
+    _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': f'{object_name} [Q10]',
                                                       'time': 5.458333374001086,
                                                       'time:unit': 'd',
                                                       'phase': 0.4583333730697632,


### PR DESCRIPTION
### Demo

```python
from lcviz import LCviz
from lightkurve import search_lightcurve

lc = search_lightcurve(
    "TRAPPIST-1", mission='K2', author='EVEREST'
)[0].download().remove_nans().normalize().remove_outliers()

# load into LCviz:
lcviz = LCviz()
lcviz.load_data(lc)
lcviz.show()

# flatten the light curve to remove rotational modulation:
flatten = lcviz.plugins['Flatten']
flatten.window_length = 31
flatten.flatten();

# query for the planets in this system:
ephem = lcviz.plugins['Ephemeris']
ephem.query_for_ephemeris()

# make a new ephemeris viewer for the first three planets:
for planet in ephem.query_result.choices[:3]:
    ephem.query_result = planet
    ephem.adopt_from_catalog_in_new_viewer()
```

<img width="1595" alt="Screen Shot 2024-07-22 at 16 29 52" src="https://github.com/user-attachments/assets/7e84d4a0-fc9b-4198-98ff-86f862a40a4b">

