### PR TITLE
Use lcviz version in all docs links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 
 * Prevent duplicate sub-intervals (quarter/sector/campaign) in data labels. [#120]
 
+0.4.2 (unreleased)
+------------------
+
+* Fix all docs links to point to correct version of read the docs. [#128]
+
 0.4.1 (07.15.2024)
 ------------------
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -9,6 +9,8 @@ from glue.core.component_id import ComponentID
 from glue.core.link_helpers import LinkSame
 from glue.core.units import unit_converter
 from jdaviz.core.helpers import ConfigHelper
+
+from lcviz import __version__
 from lcviz.viewers import TimeScatterView
 
 __all__ = ['LCviz']
@@ -134,7 +136,13 @@ class LCviz(ConfigHelper):
         self.app._add_style((__file__, 'lcviz_style.vue'))
 
         # set the link to read the docs
-        self.app.docs_link = "https://lcviz.readthedocs.io"
+        self.app.vdocs = 'latest' if 'dev' in __version__ else 'v'+__version__
+        self.app.vdocs = 'v0.4.1'  # TODO: testing only
+        self.app.docs_link = f"https://lcviz.readthedocs.io/en/{self.app.vdocs}"
+        for plugin in self.plugins.values():
+            # NOTE that plugins that need to override upstream docs_link should do so in an @observe('vdocs')
+            # rather than the init, since plugin instances have already been initialized
+            plugin._obj.vdocs = self.app.vdocs
 
     def load_data(self, data, data_label=None):
         """

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -137,7 +137,6 @@ class LCviz(ConfigHelper):
 
         # set the link to read the docs
         self.app.vdocs = 'latest' if 'dev' in __version__ else 'v'+__version__
-        self.app.vdocs = 'v0.4.1'  # TODO: testing only
         self.app.docs_link = f"https://lcviz.readthedocs.io/en/{self.app.vdocs}"
         for plugin in self.plugins.values():
             # NOTE that plugins that need to override upstream docs_link should do so in

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -140,8 +140,9 @@ class LCviz(ConfigHelper):
         self.app.vdocs = 'v0.4.1'  # TODO: testing only
         self.app.docs_link = f"https://lcviz.readthedocs.io/en/{self.app.vdocs}"
         for plugin in self.plugins.values():
-            # NOTE that plugins that need to override upstream docs_link should do so in an @observe('vdocs')
-            # rather than the init, since plugin instances have already been initialized
+            # NOTE that plugins that need to override upstream docs_link should do so in
+            # an @observe('vdocs') rather than the init, since plugin instances have
+            # already been initialized
             plugin._obj.vdocs = self.app.vdocs
 
     def load_data(self, data, data_label=None):

--- a/lcviz/plugins/export/export.py
+++ b/lcviz/plugins/export/export.py
@@ -1,3 +1,5 @@
+from traitlets import observe
+
 from jdaviz.configs.default.plugins import Export
 from jdaviz.core.registries import tray_registry
 
@@ -22,4 +24,7 @@ class Export(Export):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
         self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#export"

--- a/lcviz/plugins/markers/markers.py
+++ b/lcviz/plugins/markers/markers.py
@@ -1,4 +1,5 @@
 import numpy as np
+from traitlets import observe
 
 from jdaviz.configs.default.plugins import Markers
 from jdaviz.core.registries import tray_registry
@@ -32,6 +33,9 @@ class Markers(Markers):
         kwargs['headers'] = ['time', 'time:unit', 'phase', 'ephemeris',
                              'pixel', 'value', 'value:unit', 'viewer']
         super().__init__(*args, **kwargs)
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
         self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#markers"
 
     @property

--- a/lcviz/plugins/metadata_viewer/metadata_viewer.py
+++ b/lcviz/plugins/metadata_viewer/metadata_viewer.py
@@ -1,4 +1,5 @@
 from astropy.io.fits.card import Undefined
+from traitlets import observe
 
 from jdaviz.configs.default.plugins import MetadataViewer
 from jdaviz.core.registries import tray_registry
@@ -34,4 +35,7 @@ class MetadataViewer(MetadataViewer):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#metadata-viewer"  # noqa
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
+        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#metadata-viewer"

--- a/lcviz/plugins/metadata_viewer/metadata_viewer.py
+++ b/lcviz/plugins/metadata_viewer/metadata_viewer.py
@@ -38,4 +38,4 @@ class MetadataViewer(MetadataViewer):
 
     @observe('vdocs')
     def _update_docs_link(self, *args):
-        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#metadata-viewer"
+        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#metadata-viewer"  # noqa

--- a/lcviz/plugins/plot_options/plot_options.py
+++ b/lcviz/plugins/plot_options/plot_options.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from traitlets import observe
 from jdaviz.configs.default.plugins import PlotOptions
 from jdaviz.core.registries import tray_registry
 
@@ -31,6 +32,9 @@ class PlotOptions(PlotOptions):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
         self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#plot-options"
 
     def _default_tpf_stretch(

--- a/lcviz/plugins/subset_plugin/subset_plugin.py
+++ b/lcviz/plugins/subset_plugin/subset_plugin.py
@@ -24,4 +24,4 @@ class SubsetPlugin(SubsetPlugin):
 
     @observe('vdocs')
     def _update_docs_link(self, *args):
-        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#subset-tools"
+        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#subset-tools"  # noqa

--- a/lcviz/plugins/subset_plugin/subset_plugin.py
+++ b/lcviz/plugins/subset_plugin/subset_plugin.py
@@ -1,3 +1,5 @@
+from traitlets import observe
+
 from jdaviz.configs.default.plugins import SubsetPlugin
 from jdaviz.core.registries import tray_registry
 
@@ -18,5 +20,8 @@ class SubsetPlugin(SubsetPlugin):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#subset-tools"
         self.can_freeze = True
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
+        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#subset-tools"

--- a/lcviz/plugins/time_selector/time_selector.py
+++ b/lcviz/plugins/time_selector/time_selector.py
@@ -1,3 +1,5 @@
+from traitlets import observe
+
 from jdaviz.configs.cubeviz.plugins import Slice
 from jdaviz.core.registries import tray_registry
 
@@ -37,7 +39,6 @@ class TimeSelector(Slice):
 
         """
         super().__init__(*args, **kwargs)
-        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#time-selector"
         self.docs_description = "Select time to sync across all viewers (as an indicator in all time/phase viewers or to select the active slice in any image/cube viewers).  The slice can also be changed interactively in any time viewer by activating the slice tool."  # noqa
         self.value_label = 'Time'
         self.value_unit = 'd'
@@ -45,6 +46,10 @@ class TimeSelector(Slice):
 
         self.session.hub.subscribe(self, EphemerisChangedMessage,
                                    handler=self._on_ephemeris_changed)
+
+    @observe('vdocs')
+    def _update_docs_link(self, *args):
+        self.docs_link = f"https://lcviz.readthedocs.io/en/{self.vdocs}/plugins.html#time-selector"
 
     @property
     def slice_display_unit_name(self):


### PR DESCRIPTION
This PR ensures that all internal docs links buttons point to the correct version on RTD, and don't use the upstream version tag set by jdaviz.