### PR TITLE
bump lightkurve to 2.5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 0.4.3 (unreleased)
 ------------------
 
+* bumps lightkurve to 2.5.0 to include upstream bug fixes. [#132]
+
 
 0.4.2 (07.23.2024)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
     "jdaviz>=3.10.3,<3.11",
-    "lightkurve>=2.4.1",
+    "lightkurve>=2.5.0",
     "numpy<2",
 ]
 dynamic = [


### PR DESCRIPTION
- [ ] rerun CI once [available on pip](https://github.com/lightkurve/lightkurve/issues/1459)