### PR TITLE
FIX: add missing plugin API docs entries

### DIFF
--- a/docs/reference/api_plugins.rst
+++ b/docs/reference/api_plugins.rst
@@ -15,6 +15,9 @@ Plugins API
 .. automodapi:: lcviz.plugins.flatten.flatten
   :no-inheritance-diagram:
 
+.. automodapi:: lcviz.plugins.flux_column.flux_column
+  :no-inheritance-diagram:
+
 .. automodapi:: lcviz.plugins.frequency_analysis.frequency_analysis
   :no-inheritance-diagram:
 
@@ -25,6 +28,9 @@ Plugins API
   :no-inheritance-diagram:
 
 .. automodapi:: lcviz.plugins.plot_options.plot_options
+  :no-inheritance-diagram:
+
+.. automodapi:: lcviz.plugins.stitch.stitch
   :no-inheritance-diagram:
 
 .. automodapi:: lcviz.plugins.subset_plugin.subset_plugin


### PR DESCRIPTION
Rendered plugins page (all links from API examples should now be working): https://lcviz--134.org.readthedocs.build/en/134/plugins.html