### PR TITLE
improve initial scatter/mouseover performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 * bumps lightkurve to 2.5.0 to include upstream bug fixes. [#132]
 
+* Improve scatter viewer and mouseover performance. [#137]
+
 
 0.4.2 (07.23.2024)
 ------------------

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -89,10 +89,7 @@ class CoordsInfo(CoordsInfo):
             if self.dataset.selected != 'auto' and self.dataset.selected != lyr.layer.label:
                 continue
 
-            # glue-jupyter 1.18 changed from lyr.scatter to lyr.scatter_mark
-            # TODO: once glue-jupyter is pinned to 1.18 or later, update this to:
-            # scatter = lyr.scatter_mark
-            scatter = getattr(lyr, 'scatter_mark', getattr(lyr, 'scatter', None))
+            scatter = lyr.scatter_mark
             lyr_x, lyr_y = scatter.x, scatter.y
             if not len(lyr_x):
                 continue

--- a/lcviz/plugins/coords_info/coords_info.py
+++ b/lcviz/plugins/coords_info/coords_info.py
@@ -2,12 +2,10 @@ import numpy as np
 
 from glue.core.subset_group import GroupedSubset
 from jdaviz.configs.imviz.plugins.coords_info import CoordsInfo
-from jdaviz.core.events import ViewerRenamedMessage, SnackbarMessage
+from jdaviz.core.events import ViewerRenamedMessage
 from jdaviz.core.registries import tool_registry
 
 from lcviz.viewers import TimeScatterView, PhaseScatterView, CubeView
-
-from datetime import datetime as dt
 
 __all__ = ['CoordsInfo']
 
@@ -18,7 +16,6 @@ class CoordsInfo(CoordsInfo):
     _viewer_classes_with_marker = (TimeScatterView, PhaseScatterView)
 
     def __init__(self, *args, **kwargs):
-        self.first = True
         super().__init__(*args, **kwargs)
 
         # TODO: move to jdaviz if/once viewer renaming supported
@@ -92,25 +89,10 @@ class CoordsInfo(CoordsInfo):
             if self.dataset.selected != 'auto' and self.dataset.selected != lyr.layer.label:
                 continue
 
-            if self.first:
-                start = dt.now()
             scatter = lyr.scatter_mark
             lyr_x, lyr_y = scatter.x, scatter.y
             if not len(lyr_x):
-                self.hub.broadcast(
-                    SnackbarMessage(
-                        f"not len(lyr_x) for {lyr.layer.label}",
-                        sender=self, color="warning"
-                    )
-                )
                 continue
-            if self.first:
-                self.hub.broadcast(
-                    SnackbarMessage(
-                        f"lyr.scatter_mark retrieveal {(dt.now() - start).total_seconds()}s",
-                        sender=self, color="warning"
-                    )
-                )
 
             # NOTE: unlike specviz which determines the closest point in x per-layer,
             # this determines the closest point in x/y per-layer in pixel-space
@@ -163,17 +145,8 @@ class CoordsInfo(CoordsInfo):
 
         self.icon = closest_icon
 
-        if self.first:
-            start = dt.now()
         self.marks[viewer._reference_id].update_xy([closest_x], [closest_y])  # noqa
         self.marks[viewer._reference_id].visible = True
-        if self.first:
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"marks update_xy took {(dt.now() - start).total_seconds()}s",
-                    sender=self, color="warning"
-                )
-            )
 
     def _image_viewer_update(self, viewer, x, y):
         # Extract first dataset from visible layers and use this for coordinates - the choice
@@ -266,27 +239,7 @@ class CoordsInfo(CoordsInfo):
         if not len(viewer.state.layers):
             return
 
-        if self.first:
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"coords_info first update_display call",
-                    sender=self, color="warning"
-                )
-            )
-            start = dt.now()
-        try:
-            if isinstance(viewer, (TimeScatterView, PhaseScatterView)):
-                self._lc_viewer_update(viewer, x, y)
-            elif isinstance(viewer, CubeView):
-                self._image_viewer_update(viewer, x, y)
-        except Exception as e:
-            self._viewer_mouse_clear_event(viewer)
-        if self.first:
-            end = dt.now()
-            self.hub.broadcast(
-                SnackbarMessage(
-                    f"coords_info first update_display took {(end - start).total_seconds()}s",
-                    sender=self, color="warning"
-                )
-            )
-            self.first = False
+        if isinstance(viewer, (TimeScatterView, PhaseScatterView)):
+            self._lc_viewer_update(viewer, x, y)
+        elif isinstance(viewer, CubeView):
+            self._image_viewer_update(viewer, x, y)

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -150,6 +150,8 @@ class TimeScatterView(JdavizViewerMixin, CloneViewerMixin, WithSliceIndicator, B
             # increased size of binned results, by default
             layer_state.size = 5
         layer_state.points_mode = 'markers'
+        from jdaviz.core.events import SnackbarMessage
+        self.hub.broadcast(SnackbarMessage("Layer changed to markers mode", sender=self, color='warning'))
 
     def set_plot_axes(self):
         # set which components should be plotted

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -149,6 +149,7 @@ class TimeScatterView(JdavizViewerMixin, CloneViewerMixin, WithSliceIndicator, B
         if getattr(layer_state.layer, 'meta', {}).get('Plugin', None) == 'Binning':
             # increased size of binned results, by default
             layer_state.size = 5
+        layer_state.points_mode = 'markers'
 
     def set_plot_axes(self):
         # set which components should be plotted

--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -150,8 +150,6 @@ class TimeScatterView(JdavizViewerMixin, CloneViewerMixin, WithSliceIndicator, B
             # increased size of binned results, by default
             layer_state.size = 5
         layer_state.points_mode = 'markers'
-        from jdaviz.core.events import SnackbarMessage
-        self.hub.broadcast(SnackbarMessage("Layer changed to markers mode", sender=self, color='warning'))
 
     def set_plot_axes(self):
         # set which components should be plotted


### PR DESCRIPTION
This along with https://github.com/glue-viz/glue-jupyter/pull/467 (included in glue-jupyter 0.22.2) improves the performance at load time, especially when the server is remote.

Note that lcviz does not explicitly pin glue-jupyter (it pulls in glue-jupyter through jdaviz).