### PR TITLE
pin glue-jupyter to 0.22.2+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@
 
 * bumps lightkurve to 2.5.0 to include upstream bug fixes. [#132]
 
-* Improve scatter viewer and mouseover performance. [#137]
+* Improve scatter viewer and mouseover performance. [#137, #139]
 
 
 0.4.2 (07.23.2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     # to devdeps in tox.ini
     "jdaviz>=3.10.3,<3.11",
     "lightkurve>=2.5.0",
+    # NOTE: glue-jupyter is also pinned by jdaviz.
+    "glue-jupyter>=0.22.2",
     "numpy<2",
 ]
 dynamic = [


### PR DESCRIPTION
This pins glue-jupyter to 0.22.2+ (the pinned jdaviz only requires 0.22.1+) to ensure https://github.com/glue-viz/glue-jupyter/pull/467 is included.