### PR TITLE
prep for 1.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-0.5.0 (unreleased)
+1.0.0 (unreleased)
 ------------------
 
 * Update jdaviz requirement to 4.0 to include upstream improvements including API hints. [#121, #133]

--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,6 @@
     :alt: Powered by lightkurve Badge
 
 
-Early Development Software Warning
-----------------------------------
-LCviz is still very early on in development and is not currently recommended for use. 
-
-
 License
 -------
 


### PR DESCRIPTION
This PR renames the upcoming release from 0.5.0 to 1.0.0 and removes the early development warning from the readme.

In preparation, I also renamed the milestone from `0.5.0` > `1.0.0`.