### PR TITLE
Ignore mpl_scatter_density warning temporarily

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ filterwarnings = [
     "ignore::UserWarning:traittypes",
     "ignore::DeprecationWarning:asteval",
     "ignore::FutureWarning:asteval",
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning:mpl_scatter_density",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
Since https://github.com/spacetelescope/jdaviz/pull/3317, `jdaviz` ignores a warning raised by `mpl_scatter_density` (https://github.com/astrofrog/mpl-scatter-density/issues/46, https://github.com/astrofrog/mpl-scatter-density/pull/47). We should use the same ignore in lcviz until the upstream fix is released. 