### PR TITLE
Add parser for TESS DVT files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.1.0 (unreleased)
 ------------------
 
+* Add support for loading TESS DVT files. [#164]
+
 
 1.0.0 (12-02-2024)
 ------------------

--- a/lcviz/components/components.py
+++ b/lcviz/components/components.py
@@ -1,6 +1,5 @@
 from astropy import units as u
 from functools import cached_property
-import numpy as np
 
 from ipyvuetify import VuetifyTemplate
 from glue.core import HubListener

--- a/lcviz/components/components.py
+++ b/lcviz/components/components.py
@@ -223,7 +223,7 @@ class FluxColumnSelect(SelectPluginComponent):
         # manipulate the arrays in the data-collection directly, and modify FLUX_ORIGIN so that
         # exporting back to a lightkurve object works as expected
         self.app._jdaviz_helper._set_data_component(dc_item, 'flux', dc_item[self.selected])
-        if self.selected+"_err" in [c.label for c in dc_item.components]:
+        if self.selected+"_err" in dc_item.component_ids():
             self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err',
                                                         dc_item[self.selected+"_err"])  # noqa
         else:

--- a/lcviz/components/components.py
+++ b/lcviz/components/components.py
@@ -224,12 +224,13 @@ class FluxColumnSelect(SelectPluginComponent):
         # exporting back to a lightkurve object works as expected
         self.app._jdaviz_helper._set_data_component(dc_item, 'flux', dc_item[self.selected])
         if self.selected+"_err" in dc_item.component_ids():
-            self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err',
-                                                        dc_item[self.selected+"_err"])  # noqa
+            if "flux_err" in dc_item.component_ids():
+                self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err',
+                                                            dc_item[self.selected + "_err"])
+            else:
+                dc_item.add_component(dc_item[self.selected + "_err"], 'flux_err')
         else:
-            nan_errs = np.empty(dc_item['flux'].shape)
-            nan_errs[:] = np.nan
-            self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err', nan_errs)
+            dc_item.remove_component(dc_item.find_component_id('flux_err'))
 
         dc_item.meta['FLUX_ORIGIN'] = self.selected
 

--- a/lcviz/components/components.py
+++ b/lcviz/components/components.py
@@ -1,5 +1,6 @@
 from astropy import units as u
 from functools import cached_property
+import numpy as np
 
 from ipyvuetify import VuetifyTemplate
 from glue.core import HubListener
@@ -222,7 +223,14 @@ class FluxColumnSelect(SelectPluginComponent):
         # manipulate the arrays in the data-collection directly, and modify FLUX_ORIGIN so that
         # exporting back to a lightkurve object works as expected
         self.app._jdaviz_helper._set_data_component(dc_item, 'flux', dc_item[self.selected])
-        self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err', dc_item[self.selected+"_err"])  # noqa
+        if self.selected+"_err" in [c.label for c in dc_item.components]:
+            self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err',
+                                                        dc_item[self.selected+"_err"])  # noqa
+        else:
+            nan_errs = np.empty(dc_item['flux'].shape)
+            nan_errs[:] = np.nan
+            self.app._jdaviz_helper._set_data_component(dc_item, 'flux_err', nan_errs)
+
         dc_item.meta['FLUX_ORIGIN'] = self.selected
 
         self.hub.broadcast(FluxColumnChangedMessage(dataset=self.dataset.selected,

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -175,6 +175,7 @@ class LCviz(ConfigHelper):
                                   parser_reference='tess_dvt_parser',
                                   data_label=data_label,
                                   extname=extname)
+                return
 
         super().load_data(
             data=data,

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -1,3 +1,4 @@
+from astropy.io.fits import getheader
 import astropy.units as u
 import ipyvue
 import os
@@ -144,7 +145,7 @@ class LCviz(ConfigHelper):
             # already been initialized
             plugin._obj.vdocs = self.app.vdocs
 
-    def load_data(self, data, data_label=None):
+    def load_data(self, data, data_label=None, extname=None):
         """
         Load data into LCviz.
 
@@ -161,7 +162,20 @@ class LCviz(ConfigHelper):
             automatically determined from filename or randomly generated.
             The final label shown in LCviz may have additional information
             appended for clarity.
+        extname : str or `None`
+            Used for DVT parsing if only a single TCE from a multi-TCE file should be
+            loaded. Formatted as 'TCE_1', 'TCE_2', etc.
         """
+        # Determine if we're loading a DVT file, which has a separate parser
+        if isinstance(data, str):
+            header = getheader(data)
+            if (header['TELESCOP'] == 'TESS' and 'CREATOR' in header and
+                    'DvTimeSeriesExporter' in header['CREATOR']):
+                super().load_data(data=data,
+                                  parser_reference='tess_dvt_parser',
+                                  data_label=data_label,
+                                  extname=extname)
+
         super().load_data(
             data=data,
             parser_reference='light_curve_parser',

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -65,7 +65,6 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
             ephem_plugin.t0 = header['TEPOCH'] + time_offset - app.data_collection[0].coords.reference_time.jd  # noqa
 
 
-
 @data_parser_registry("light_curve_parser")
 def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwargs):
     # load a LightCurve or TargetPixelFile object:

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -33,7 +33,7 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
     # `extname` keyword) then only load that one into the viewers and ephemeris.
     for i in range(1, len(hdulist)-1):
         data = Table(hdulist[i].data)
-        # don't load some columns with names that may 
+        # don't load some columns with names that may
         # conflict with components generated later by lcviz
         data.remove_column('PHASE')
         data.remove_column('CADENCENO')
@@ -62,7 +62,8 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
         # add ephemeris information from the DVT extension
         if ephem_plugin is not None and show_ext_in_viewer:
             ephem_plugin.period = header['TPERIOD']
-            ephem_plugin.t0 = header['TEPOCH'] + time_offset
+            ephem_plugin.t0 = header['TEPOCH'] + time_offset - app.data_collection[0].coords.reference_time.jd  # noqa
+
 
 
 @data_parser_registry("light_curve_parser")

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -46,7 +46,7 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
         light_curve_parser(app, lc, data_label=data_label,
                            show_in_viewer=show_ext_in_viewer, **kwargs)
 
-        # add to any known phase viewers
+        # add ephemeris information from the DVT extension
         if ephem_plugin is not None and show_ext_in_viewer:
             ephem_plugin.period = header['TPERIOD']
             ephem_plugin.t0 = header['TEPOCH']

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -14,6 +14,7 @@ mission_sub_intervals = {
     'kepler': {'prefix': 'Q', 'card': 'QUARTER'},
     'k2': {'prefix': 'C', 'card': 'CAMPAIGN'},
     'tess': {'prefix': 'S', 'card': 'SECTOR'},
+    'tess dvt': {'prefix': '', 'card': 'EXTNAME'}
 }
 
 
@@ -35,8 +36,9 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
                                    flux=data['LC_INIT'],
                                    flux_err=data['LC_INIT_ERR'])
         lc.meta = hdulist[0].header
-        lc.meta['MISSION'] = 'TESS'
+        lc.meta['MISSION'] = 'TESS DVT'
         lc.meta['FLUX_ORIGIN'] = "LC_INIT"
+        lc.meta['EXTNAME'] = header['EXTNAME']
 
         if extname is not None and header['EXTNAME'] != extname:
             show_ext_in_viewer = False

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -31,15 +31,15 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
 
     # Loop through the TCEs in the file. If we only want one (specified by
     # `extname` keyword) then only load that one into the viewers and ephemeris.
-    for i in range(1, len(hdulist)-1):
-        data = Table(hdulist[i].data)
+    for hdu in hdulist[1:]:
+        data = Table(hdu.data)
         # don't load some columns with names that may
         # conflict with components generated later by lcviz
         data.remove_column('PHASE')
         data.remove_column('CADENCENO')
         # Remove rows that have NaN data
         data = data[~np.isnan(data['LC_INIT'])]
-        header = hdulist[i].header
+        header = hdu.header
         time_offset = int(header['TUNIT1'] .split('- ')[1].split(',')[0])
         data['TIME'] += time_offset
         lc = lightkurve.LightCurve(data=data,

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -33,7 +33,8 @@ def tess_dvt_parser(app, file_obj, data_label=None, show_in_viewer=True, **kwarg
     # `extname` keyword) then only load that one into the viewers and ephemeris.
     for i in range(1, len(hdulist)-1):
         data = Table(hdulist[i].data)
-        # We don't want these columns
+        # don't load some columns with names that may 
+        # conflict with components generated later by lcviz
         data.remove_column('PHASE')
         data.remove_column('CADENCENO')
         # Remove rows that have NaN data


### PR DESCRIPTION
By default, this will load each TCE extension into the data collection as a separate object and display them all. Specifying `extname` will skip adding the deselected extensions into viewers. Opening as draft since I need to fix the auto-generated data label. I probably also need to think a little harder about what to do with the ephemeris in the case of multiple TCE extensions that are all added to the viewer.

<img width="1472" alt="Screenshot 2024-12-31 at 12 49 10 PM" src="https://github.com/user-attachments/assets/12778b12-96bd-467e-9697-9bfd5bb027e0" />
