### PR TITLE
Swap lightkurve periodogram for astropy method in Ephemeris

### DIFF
--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -3,6 +3,7 @@ from astropy.coordinates import SkyCoord
 from astropy.time import Time
 import astropy.units as u
 from astroquery.ipac.nexsci.nasa_exoplanet_archive import NasaExoplanetArchive
+from astropy.timeseries import LombScargle
 
 from traitlets import Bool, Float, List, Unicode, observe
 
@@ -562,13 +563,26 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         if self.method == 'Box Least Squares':
             try:
                 per = periodogram.BoxLeastSquaresPeriodogram.from_lightcurve(self.dataset.selected_obj)  # noqa
+
+                # TODO: will need to return in display units once supported
+                self.period_at_max_power = per.period_at_max_power.value
+
             except Exception as err:
                 self.method_spinner = False
                 self.method_err = str(err)
                 return
+
         elif self.method == 'Lomb-Scargle':
             try:
-                per = periodogram.LombScarglePeriodogram.from_lightcurve(self.dataset.selected_obj)
+                lc = self.dataset.selected_obj
+                ls = LombScargle(lc.time, lc.flux, lc.flux_err, normalization='psd')
+
+                freq = ls.autofrequency()
+                power = ls.power(freq)
+
+                # TODO: will need to return in display units once supported
+                self.period_at_max_power = (1 / freq[np.argmax(power)]).value
+
             except Exception as err:
                 self.method_spinner = False
                 self.method_err = str(err)
@@ -577,8 +591,6 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
             self.method_spinner = False
             raise NotImplementedError(f"periodogram not implemented for {self.method}")
 
-        # TODO: will need to return in display units once supported
-        self.period_at_max_power = per.period_at_max_power.value
         self.method_spinner = False
 
     def adopt_period_at_max_power(self):


### PR DESCRIPTION
If you load data into LCviz with sampling varying from minutes apart to decades apart, the lightkurve.periodogram functionality chokes. It chokes because there are some assumptions that lightkurve makes that cause issues here. The main assumption is about time sampling. The time difference between the nearest measurements in this series is of order minutes, but the full span is decades. Sampling evenly at the nyquist frequency gives a tremendous array
and by default, lightkurve uses an O(N^2) implementation of the L-S periodogram. One very simple solution is to not make the same assumptions as lightkurve does.

Ephemeris calls this on the data:

https://github.com/spacetelescope/lcviz/blob/9d39dfdc70a425a538dea9d048cf0cfe3ef6882f/lcviz/plugins/ephemeris/ephemeris.py#L571

which is where the problems start.

We can fix that up like this:
```python
lc = self.dataset.selected_obj
ls = LombScargle(lc.time, lc.flux, lc.flux_err, normalization='psd')
freq = ls.autofrequency()
power = ls.power(freq)
self.period_at_max_power = (1 / freq[np.argmax(power)]).value
```
just using the astropy L-S implementation directly without going through lightkurve overcomes the frequency array problem.