### PR TITLE
Extract reference time from data collection

### DIFF
--- a/lcviz/viewers.py
+++ b/lcviz/viewers.py
@@ -161,16 +161,17 @@ class TimeScatterView(JdavizViewerMixin, CloneViewerMixin, WithSliceIndicator, B
         self._set_plot_x_axes(dc, component_labels, light_curve)
         self._set_plot_y_axes(dc, component_labels, light_curve)
 
-    def _set_plot_x_axes(self, dc, component_labels, light_curve):
+    def _set_plot_x_axes(self, dc, component_labels, light_curve=None, reference_time=None):
         self.state.x_att = dc[0].components[component_labels.index('dt')]
 
         x_unit = self.time_unit
-        reference_time = light_curve.meta.get('reference_time', None)
 
-        if reference_time is not None:
-            xlabel = f'{str(x_unit.physical_type).title()} from {reference_time.iso} ({x_unit})'
-        else:
-            xlabel = f'{str(x_unit.physical_type).title()} ({x_unit})'
+        if light_curve is not None and reference_time is None:
+            reference_time = light_curve.meta.get('reference_time', None)
+        elif reference_time is None:
+            reference_time = dc[0].coords.reference_time
+
+        xlabel = f'{str(x_unit.physical_type).title()} from {reference_time.iso} ({x_unit})'
 
         self.figure.axes[0].label = xlabel
         self.figure.axes[0].num_ticks = 5


### PR DESCRIPTION
The reference viewer x-axis is set by `TimeScatterView._set_plot_x_axes`, which currently requires that you pass in a `LightCurve` with a reference time in the `meta` attribute. The function already requires you to pass a `DataCollection`, which should also have at least one entry with a reference time on its `TimeCoordinate`.

This PR allows you to set the x-axis without a `LightCurve`, which is useful if you want to change the axes for an already-loaded light curve in the data collection.