### PR TITLE
TST: test updates for changes in remote data

### DIFF
--- a/lcviz/tests/test_plugin_markers.py
+++ b/lcviz/tests/test_plugin_markers.py
@@ -147,18 +147,18 @@ def test_tpf_markers(helper, light_curve_like_kepler_quarter):
                                         {'event': 'mousemove',
                                          'domain': {'x': 0, 'y': 0}})
 
-    assert label_mouseover.as_text() == ('Pixel x=00000.0 y=00000.0 Value +1.27220e+00 electron / s',  # noqa
-                                         'Time 47.00000 d',
+    assert label_mouseover.as_text() == ('Pixel x=00000.0 y=00000.0 Value +1.28035e+01 electron / s',  # noqa
+                                         'Time 47.00689 d',
                                          '')
 
     print(label_mouseover.as_dict())
     _assert_dict_allclose(label_mouseover.as_dict(), {'data_label': 'KIC 1429092[TPF]',
-                                                      'time': 47.00000,
+                                                      'time': 47.00689,
                                                       'time:unit': 'd',
                                                       'pixel': (0.0, 0.0),
                                                       'axes_x': 0,
                                                       'axes_x:unit': 'pix',
                                                       'axes_y': 0,
                                                       'axes_y:unit': 'pix',
-                                                      'value': 1.272199273109436,
+                                                      'value': 12.803529,
                                                       'value:unit': 'electron / s'})


### PR DESCRIPTION
~This PR updates values in the markers tests caused by changes to remote data (or at least that's what we assume - these tests were always just fixed to get the same results).~

Since this is failing here (and giving the same results as before the changes), that means that the test break is caused by jdaviz 4.0 -> 4.1 instead.