### PR TITLE
fix link to lightkurve docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@
 ******************
 
 ``lcviz`` is a light curve visualization and analysis tool within the Jupyter environment (lab or 
-notebook), built on top of `Jdaviz <https://jdaviz.readthedocs.io>`_ and `lightkurve <https://docs.lightkurve.org>`_::
+notebook), built on top of `Jdaviz <https://jdaviz.readthedocs.io>`_ and `lightkurve <https://lightkurve.github.io/lightkurve/>`_::
 
     from lcviz import LCviz
     from lightkurve import search_lightcurve


### PR DESCRIPTION
docs.lightkurve.org is the old link, which is now broken -- this updates to the latest link