### PR TITLE
add missing api-hint for binning.ephemeris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 
 * Update jdaviz requirement to 4.1 to include upstream improvements, including plugin descriptions and redesigned data menu [#158]
 
+* Add missing API hint for lcviz.plugins['Binning'].ephemeris. [#178]
 
 1.0.0 (12-02-2024)
 ------------------

--- a/lcviz/components/plugin_ephemeris_select.vue
+++ b/lcviz/components/plugin_ephemeris_select.vue
@@ -17,7 +17,10 @@
     >
     <template slot="selection" slot-scope="data">
       <div class="single-line">
-        <span>
+        <span v-if="api_hints_enabled" class="api-hint">
+          '{{selected}}'
+        </span>
+        <span v-else>
           {{ data.item.label }}
         </span>
       </div>

--- a/lcviz/plugins/binning/binning.vue
+++ b/lcviz/plugins/binning/binning.vue
@@ -47,6 +47,8 @@
       :selected.sync="ephemeris_selected"
       :show_if_single_entry="false"
       label="Ephemeris"
+      api_hint="plg.ephemeris ="
+      :api_hints_enabled="api_hints_enabled"
       hint="Select the phase-folding as input."
     />
 


### PR DESCRIPTION
This PR adds the API hint for `lcviz.plugins['Binnning'].ephemeris`.