### PR TITLE
Fix stitch data removal with Jdaviz 4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@
 * Removed ``lcviz.test()``. Use ``pytest --pyargs lcviz <options>"`` instead
   to test your copy of ``lcviz``. [#172]
 
-* Update jdaviz requirement to 4.2 to include upstream improvements, including plugin descriptions and redesigned data menu [#158, #165]
+* Update jdaviz requirement to 4.2 to include upstream improvements, including plugin
+  descriptions and redesigned data menu [#158, #165, #180]
 
 * Add missing API hint for lcviz.plugins['Binning'].ephemeris. [#178]
 

--- a/lcviz/plugins/stitch/stitch.py
+++ b/lcviz/plugins/stitch/stitch.py
@@ -85,7 +85,7 @@ class Stitch(PluginTemplateMixin, DatasetMultiSelectMixin, AddResultsMixin):
             self.add_results.add_results_from_plugin(stitched_lc)
             if self.remove_input_datasets:
                 for dataset in self.dataset.selected:
-                    self.app.vue_data_item_remove({'item_name': dataset})
+                    self.app.data_item_remove(dataset)
         return stitched_lc
 
     def vue_apply(self, *args, **kwargs):

--- a/lcviz/tests/test_plugin_stitch.py
+++ b/lcviz/tests/test_plugin_stitch.py
@@ -26,6 +26,8 @@ def test_plugin_stitch(helper, light_curve_like_kepler_quarter):
 
     stitch = helper.plugins['Stitch']
     stitch.dataset.select_all()
+    stitch.remove_input_datasets = True
     stitched_lc = stitch.stitch()
 
     assert len(stitched_lc) == 2 * len(light_curve_like_kepler_quarter)
+    assert len(helper.app.data_collection) == 1


### PR DESCRIPTION
Jdaviz no longer has an `app.vue_data_item_remove` method, so this needed to be updated to use the backend method.