### PR TITLE
parser: do not require TELESCOP to be set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 1.1.1 (unreleased)
 ------------------
 
+* Fix loading files without TELESCOP set. [#182]
+
 1.1.0 (03-25-2025)
 ------------------
 

--- a/lcviz/helper.py
+++ b/lcviz/helper.py
@@ -169,7 +169,7 @@ class LCviz(ConfigHelper):
         # Determine if we're loading a DVT file, which has a separate parser
         if isinstance(data, str):
             header = getheader(data)
-            if (header['TELESCOP'] == 'TESS' and 'CREATOR' in header and
+            if (header.get('TELESCOP', '') == 'TESS' and 'CREATOR' in header and
                     'DvTimeSeriesExporter' in header['CREATOR']):
                 super().load_data(data=data,
                                   parser_reference='tess_dvt_parser',


### PR DESCRIPTION
This PR allows files to be parsed where `TELESCOP` is not set.