### PR TITLE
fix bug in setting wrap_at of non-active ephem component

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 
 * Add missing plugin description for the Stitch plugin. [#185]
 
+* Fixes the case of setting original phase-viewer limits of a non-selected ephemeris component [#188]
+
 1.1.0 (03-25-2025)
 ------------------
 

--- a/lcviz/plugins/ephemeris/ephemeris.py
+++ b/lcviz/plugins/ephemeris/ephemeris.py
@@ -369,7 +369,8 @@ class Ephemeris(PluginTemplateMixin, DatasetSelectMixin):
         pv.state.x_att = phase_comp
 
         # set viewer limits
-        pv.state.x_min, pv.state.x_max = (self.wrap_at-1, self.wrap_at)
+        wrap_at = self.ephemerides.get(ephem_component, {}).get('wrap_at', self.wrap_at)
+        pv.state.x_min, pv.state.x_max = (wrap_at-1, wrap_at)
 
         return pv.user_api
 


### PR DESCRIPTION
This PR fixes the case of setting original phase-viewer limits of a non-selected ephemeris component