### PR TITLE
Fix for translating light curves as LightCurve objects rather than Tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@
 
 * Fixes the case of setting original phase-viewer limits of a non-selected ephemeris component [#188]
 
-* Fix for ``lighkurve.LightCurve`` glue data translators, workaround warnings raised by ``spectral_cube``,
+* Fix for ``lightkurve.LightCurve`` glue data translators introduced by glue-astronomy 0.12, workaround warnings raised by ``spectral_cube``,
   ensure folded light curves have the ``normalize_phase`` attribute [#194]
 
 1.1.0 (03-25-2025)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
 
 * Fixes the case of setting original phase-viewer limits of a non-selected ephemeris component [#188]
 
+* Fix for ``lighkurve.LightCurve`` glue data translators, workaround warnings raised by ``spectral_cube``,
+  ensure folded light curves have the ``normalize_phase`` attribute [#194]
+
 1.1.0 (03-25-2025)
 ------------------
 

--- a/lcviz/parsers.py
+++ b/lcviz/parsers.py
@@ -2,13 +2,13 @@ import os
 
 from astropy.io import fits
 from astropy.table import Table
-from glue.config import data_translator
 from jdaviz.core.registries import data_parser_registry
 import lightkurve
 import numpy as np
 
 from lcviz.viewers import PhaseScatterView, TimeScatterView
 from lcviz.plugins.plot_options import PlotOptions
+from lcviz.utils import LightCurveHandler
 
 __all__ = ["light_curve_parser"]
 
@@ -154,6 +154,9 @@ def light_curve_parser(app, file_obj, data_label=None, show_in_viewer=True, **kw
                     app.add_data_to_viewer(viewer.reference, data_label)
 
 
+light_curve_handler = LightCurveHandler()
+
+
 def _data_with_reftime(app, light_curve):
     # grab the first-found reference time in the data collection:
     ff_reference_time = None
@@ -164,5 +167,4 @@ def _data_with_reftime(app, light_curve):
                 break
 
     # convert to glue Data manually, so we may edit the `dt` component if necessary:
-    handler, _ = data_translator.get_handler_for(light_curve)
-    return handler.to_data(light_curve, reference_time=ff_reference_time)
+    return light_curve_handler.to_data(light_curve, reference_time=ff_reference_time)

--- a/lcviz/plugins/binning/binning.py
+++ b/lcviz/plugins/binning/binning.py
@@ -223,6 +223,11 @@ class Binning(PluginTemplateMixin, FluxColumnSelectMixin, DatasetSelectMixin,
 
         input_lc = self.input_lc
 
+        # fix for bug in py310, see:
+        # https://github.com/spacetelescope/lcviz/pull/194
+        if "NORMALIZE_PHASE" not in input_lc.meta:
+            input_lc.meta["NORMALIZE_PHASE"] = False
+
         lc = input_lc.bin(time_bin_size=(input_lc.time[-1]-input_lc.time[0]).value/self.n_bins)
         if self.ephemeris_selected != 'No ephemeris':
             # lc.time.value are actually phases, so convert to times starting at time t0

--- a/lcviz/tests/test_plugin_binning.py
+++ b/lcviz/tests/test_plugin_binning.py
@@ -30,6 +30,7 @@ def test_plugin_binning(helper, light_curve_like_kepler_quarter):
     pv = ephem.create_phase_viewer()._obj
 
     with b.as_active():
+        b.show_live_preview = True
         assert b.ephemeris == 'No ephemeris'
         assert len(_get_marks_from_viewer(tv)) == 1
         assert len(_get_marks_from_viewer(pv)) == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,11 @@ filterwarnings = [
     "ignore::FutureWarning:asteval",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:mpl_scatter_density",
 
+    # this will be unnecessary after jdaviz merges and releases:
+    # https://github.com/spacetelescope/jdaviz/pull/3683
+    "ignore:.*The TestRunner class will be deprecated in a future version.*",
+    "ignore:.*The TestRunnerBase class will be deprecated in a future version.*",
+
     # this suppresses a warning from lightkurve that reads: "UserWarning: Warning: the tpfmodel 
     # submodule is not available without oktopus installed, which requires a current version of
     # autograd. See #1452 for details." 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ filterwarnings = [
     "ignore::DeprecationWarning:asteval",
     "ignore::FutureWarning:asteval",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:mpl_scatter_density",
+
+    # this suppresses a warning from lightkurve that reads: "UserWarning: Warning: the tpfmodel 
+    # submodule is not available without oktopus installed, which requires a current version of
+    # autograd. See #1452 for details." 
+    "ignore::UserWarning:lightkurve",  
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
A new glue translator for `astropy.table.Table` was recently added by a PR from @rosteen, https://github.com/glue-viz/glue-astronomy/pull/103. The `Table` handler is getting returned via `data_translator.get_handler_for` because `isinstance(LightCurve(), Table) == True`, even though we really need to check `expected_cls is target_cls`. 

This PR calls the `LightCurveHandler` directly to workaround the registry misfire while we sort that out with Tom.

The relevant bit of the glue translator logic is here: https://github.com/glue-viz/glue/blob/bf65166f1f8a4367d4b43195a38e4ff653385d6b/glue/config.py#L514