### PR TITLE
jdaviz 4.4 updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 1.2.1 (unreleased)
 ------------------
 
+* Update jdaviz requirement to 4.4 to include upstream improvements including support for
+  selecting/naming the viewer within the loaders as well as improvements to the logger. [#204]
+
 
 1.2.0 (09-17-2025)
 ------------------

--- a/lcviz/loaders/importers/lightcurve/lightcurve.py
+++ b/lcviz/loaders/importers/lightcurve/lightcurve.py
@@ -140,15 +140,9 @@ class LightCurveImporter(BaseImporterToDataCollection):
             self.data_label_default = f"{self.input[0].header.get('OBJECT', 'Light curve')} [{self.extension.selected_item['name']}]"  # noqa
             self.create_ephemeris_available = has_ephem(self.output)
 
-    @property
-    def default_viewer_label(self):
-        return 'flux-vs-time'
-
-    @property
-    def default_viewer_reference(self):
-        # returns the registry name of the default viewer
-        # only used if `show_in_viewer=True` and no existing viewers can accept the data
-        return 'lcviz-time-viewer'
+    @staticmethod
+    def _get_supported_viewers():
+        return [{'label': 'flux-vs-time', 'reference': 'lcviz-time-viewer'}]
 
     @cached_property
     def output(self):
@@ -179,13 +173,13 @@ class LightCurveImporter(BaseImporterToDataCollection):
         data = _data_with_reftime(self.app, data)
         super().add_to_data_collection(data, *args, **kwargs)
 
-    def __call__(self, show_in_viewer=True):
+    def __call__(self):
         if self.input_hdulist and self.extension_multiselect:
             data_label = self.data_label_value
             lcs = self.output
             with self.app._jdaviz_helper.batch_load():
                 for lc, ext in zip(lcs, self.extension.selected_name):
-                    self.add_to_data_collection(lc, f"{data_label} [{ext}]", show_in_viewer=True)
+                    self.add_to_data_collection(lc, f"{data_label} [{ext}]")
         else:
             super().__call__()
             lcs = [self.output]

--- a/lcviz/loaders/importers/lightcurve/lightcurve.vue
+++ b/lcviz/loaders/importers/lightcurve/lightcurve.vue
@@ -32,6 +32,25 @@
       :api_hints_enabled="api_hints_enabled"
       :hint="input_hdulist && extension_multiselect ? 'Base label to assign to new data entries (will include extension as suffix).' : 'Label to assign to the new data entry.'"
     ></plugin-auto-label>
+
+    <plugin-viewer-create-new
+      :items="viewer_items"
+      :selected.sync="viewer_selected"
+      :create_new_items="viewer_create_new_items"
+      :create_new_selected.sync="viewer_create_new_selected"
+      :new_label_value.sync="viewer_label_value"
+      :new_label_default="viewer_label_default"
+      :new_label_auto.sync="viewer_label_auto"
+      :new_label_invalid_msg="viewer_label_invalid_msg"
+      :multiselect="viewer_multiselect"
+      :show_multiselect_toggle="false"
+      label="Viewer for Light Curve"
+      api_hint='ldr.importer.viewer = '
+      :api_hints_enabled="api_hints_enabled"
+      :show_if_single_entry="true"
+      hint="Select the viewer to use for the new 1D Light Curve data entry."
+    ></plugin-viewer-create-new>
+
     <plugin-switch
       v-if="create_ephemeris_available"
       :value.sync="create_ephemeris"
@@ -40,5 +59,20 @@
       :api_hints_enabled="api_hints_enabled"
       :hint="extension_multiselect && extension_selected.length > 1 ? 'Create ephemerides entries and phase-viewers.': 'Create ephemeris entry and phase-viewer.'"
     />
-  </v-contatiner>
+
+    <v-row justify="end">
+      <plugin-action-button
+        :spinner="import_spinner"
+        :disabled="import_disabled"
+        :results_isolated_to_plugin="false"
+        :api_hints_enabled="api_hints_enabled"
+        @click="import_clicked">
+        {{ api_hints_enabled ?
+          'ldr.importer()'
+          :
+          'Import'
+        }}
+      </plugin-action-button>
+    </v-row>
+  </v-container>
 </template>

--- a/lcviz/loaders/importers/tpf/tpf.py
+++ b/lcviz/loaders/importers/tpf/tpf.py
@@ -25,9 +25,9 @@ class TPFImporter(BaseImporterToDataCollection):
             return False
         return isinstance(self.input, (KeplerTargetPixelFile, TessTargetPixelFile))
 
-    @property
-    def default_viewer_label(self):
-        return 'image'
+    @staticmethod
+    def _get_supported_viewers():
+        return [{'label': 'image', 'reference': 'lcviz-cube-viewer'}]
 
     @property
     def ignore_viewers_with_cls(self):
@@ -35,12 +35,6 @@ class TPFImporter(BaseImporterToDataCollection):
         # load automatically and instead default to creating and loading into
         # an image viewer
         return (TimeScatterView, PhaseScatterView)
-
-    @property
-    def default_viewer_reference(self):
-        # returns the registry name of the default viewer
-        # only used if `show_in_viewer=True` and no existing viewers can accept the data
-        return 'lcviz-cube-viewer'
 
     @property
     def output(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "astropy>=5.2",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz>=4.3.2,<4.4",
+    "jdaviz>=4.4,<4.5",
     "lightkurve>=2.5.1",
     # NOTE: glue-jupyter is also pinned by jdaviz.
     "glue-jupyter>=0.22.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "astropy>=5.2",
     # NOTE: if/when we stop pinning a minor version of jdaviz, add jdaviz
     # to devdeps in tox.ini
-    "jdaviz>=4.4,<4.5",
+    "jdaviz>=4.4.1,<4.5",
     "lightkurve>=2.5.1",
     # NOTE: glue-jupyter is also pinned by jdaviz.
     "glue-jupyter>=0.22.2",


### PR DESCRIPTION
This PR updates lcviz to be compatible with jdaviz 4.4, including support for selecting/naming the viewer within the loaders as well as improvements to the logger.


**Waiting for**:
- [x] https://github.com/spacetelescope/jdaviz/pull/3774 to be merged and included in jdaviz 4.4
- [x] rebase to main after #183 is merged
- [x] jdaviz 4.4 release and update pin here
- [x] jdaviz 4.4.1 (including https://github.com/spacetelescope/jdaviz/pull/3797) and passing CI here
